### PR TITLE
#34 Fix map structure lost when compiling

### DIFF
--- a/lib/lotus/assets/compiler.rb
+++ b/lib/lotus/assets/compiler.rb
@@ -123,7 +123,8 @@ module Lotus
       # @since 0.1.0
       # @api private
       def basename
-        result = ::File.basename(@name)
+        # assets folder is default of apps/web/assets, upgrated in lotus v 0.6.0
+        result = @name.to_s.split('/assets/').last
 
         if compile?
           result.scan(/\A[[[:alnum:]][\-\_]]*\.[[\w]]*/).first || result

--- a/lib/lotus/assets/compiler.rb
+++ b/lib/lotus/assets/compiler.rb
@@ -124,8 +124,7 @@ module Lotus
       # @api private
       def basename
         # assets folder is default of apps/web/assets, upgrated in lotus v 0.6.0
-        result = @name.to_s.split('/assets/').last
-
+        result = @name.to_s.split('/assets/').last || ::File.basename(@name)
         if compile?
           result.scan(/\A[[[:alnum:]][\-\_]]*\.[[\w]]*/).first || result
         else


### PR DESCRIPTION
It's create right structure after compiled.

Ex:
`apps/web/assets/dist/css/AdminLTE.min.css` and after compiled is `root_project/public/assets/web/dist/css/AdminLTE.min.css`

`result = @name.to_s.split('/assets/').last || ::File.basename(@name)` to get sub-folder or not in any sub-folder.