### PR TITLE
Fix SimpleCov deprecation message

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,10 +5,10 @@ if ENV['COVERAGE'] == 'true'
   require 'simplecov'
   require 'coveralls'
 
-  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
+  SimpleCov.formatters = [
     SimpleCov::Formatter::HTMLFormatter,
     Coveralls::SimpleCov::Formatter
-  ])
+  ]
 
   SimpleCov.start do
     command_name 'test'


### PR DESCRIPTION
This avoids the following deprecation message:

```
test/test_helper.rb:8:in `<top (required)>': [DEPRECATION] ::[] is deprecated. Use ::new instead.
```