### PR TITLE
Rename `digest` to `fingerprint`

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,19 +372,19 @@ Hanami::Assets.configure do
 end
 ```
 
-### Digest Mode
+### Fingerprint Mode
 
 This is a mode that can be activated via configuration and it's suitable for production environments.
-When generating files, it adds a string to the end of each file name, which is a cachesum of its contents.
+When generating files, it adds a string to the end of each file name, which is a [checksum](https://en.wikipedia.org/wiki/Checksum).
 This lets you leverage caching while still ensuring that clients get the most up-to-date assets (this is known as *cache busting*).
 
 ```ruby
 Hanami::Assets.configure do
-  digest true
+  fingerprint true
 end
 ```
 
-Once turned on, it will look at `/public/assets.json`, and helpers such as `javascript` will return a relative URL that includes the digest of the asset.
+Once turned on, it will look at `/public/assets.json`, and helpers such as `javascript` will return a relative URL that includes the fingerprint of the asset.
 
 ```erb
 <%= javascript 'application' %>

--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ end
 ### Fingerprint Mode
 
 This is a mode that can be activated via configuration and it's suitable for production environments.
-When generating files, it adds a string to the end of each file name, which is a [checksum](https://en.wikipedia.org/wiki/Checksum).
+When generating files, it adds a string to the end of each file name, which is a [checksum](https://en.wikipedia.org/wiki/Checksum) of its contents.
 This lets you leverage caching while still ensuring that clients get the most up-to-date assets (this is known as *cache busting*).
 
 ```ruby

--- a/lib/hanami/assets/bundler.rb
+++ b/lib/hanami/assets/bundler.rb
@@ -46,12 +46,12 @@ module Hanami
       # For each asset contained in the sources and third party gems, it will:
       #
       #   * Compress
-      #   * Create a checksum version
-      #   * Generate an integrity digest
+      #   * Create a fingerprinted version of the file
+      #   * Generate a subresource integrity digest
       #
-      # At the end it will generate a digest manifest
+      # At the end it will generate a manifest
       #
-      # @see Hanami::Assets::Configuration#digest
+      # @see Hanami::Assets::Configuration#fingerprint
       # @see Hanami::Assets::Configuration#manifest
       # @see Hanami::Assets::Configuration#manifest_path
       def run

--- a/lib/hanami/assets/config/manifest.rb
+++ b/lib/hanami/assets/config/manifest.rb
@@ -5,7 +5,7 @@ module Hanami
     #
     # @since 0.1.0
     # @api private
-    class MissingDigestManifestError < Error
+    class MissingManifestFileError < Error
       def initialize(path)
         super("Can't read manifest: #{path}")
       end
@@ -16,7 +16,7 @@ module Hanami
     #
     # @since 0.1.0
     # @api private
-    class MissingDigestAssetError < Error
+    class MissingManifestAssetError < Error
       def initialize(asset, manifest_path)
         super("Can't find asset `#{asset}' in manifest (#{manifest_path})")
       end
@@ -36,7 +36,7 @@ module Hanami
       #
       # If for some reason that won't happen, the instance of this class is
       # still referenced by the configuration and all the method invocations
-      # will raise a <tt>Hanami::Assets::MissingDigestManifestError</tt>.
+      # will raise a <tt>Hanami::Assets::MissingManifestFileError</tt>.
       #
       # @since 0.1.0
       # @api private
@@ -57,13 +57,13 @@ module Hanami
           @configuration = configuration
         end
 
-        # @raise [Hanami::Assets::MissingDigestManifestError]
+        # @raise [Hanami::Assets::MissingManifestFileError]
         #
         # @since 0.1.0
         # @api private
         def method_missing(*)
           ::Kernel.raise(
-            ::Hanami::Assets::MissingDigestManifestError.new(@configuration.manifest_path)
+            ::Hanami::Assets::MissingManifestFileError.new(@configuration.manifest_path)
           )
         end
       end
@@ -107,11 +107,11 @@ module Hanami
         #
         # @return [String] the digest path
         #
-        # @raise [Hanami::Assets::MissingDigestAssetError] when the asset can't be
+        # @raise [Hanami::Assets::MissingManifestAssetError] when the asset can't be
         #   found in manifest
         def resolve(asset)
           @assets.fetch(asset.to_s) do
-            raise Hanami::Assets::MissingDigestAssetError.new(asset, @manifest_path)
+            raise Hanami::Assets::MissingManifestAssetError.new(asset, @manifest_path)
           end
         end
 

--- a/lib/hanami/assets/config/manifest.rb
+++ b/lib/hanami/assets/config/manifest.rb
@@ -1,7 +1,7 @@
 module Hanami
   module Assets
     # This error is raised when the application starts but can't be load the
-    # digest manifest.
+    # manifest file.
     #
     # @since 0.1.0
     # @api private
@@ -12,7 +12,7 @@ module Hanami
     end
 
     # This error is raised when an asset is referenced from the DOM, but it's
-    # not present in the digest manifest
+    # not present in the manifest
     #
     # @since 0.1.0
     # @api private
@@ -27,9 +27,9 @@ module Hanami
     # @since 0.1.0
     # @api private
     module Config
-      # Default value for configuration's digest manifest.
+      # Default value for configuration's manifest.
       #
-      # It indicates that the digest manifest wasn't loaded yet.
+      # It indicates that the manifest wasn't loaded yet.
       #
       # At the load time, this should be replaced by an instance of
       # <tt>Hanami::Assets::Config::Manifest</tt>.
@@ -43,7 +43,7 @@ module Hanami
       #
       # @see Hanami::Assets::Configuration#manifest
       # @see Hanami::Assets::Configuration#manifest_path
-      # @see Hanami::Assets::Configuration#digest
+      # @see Hanami::Assets::Configuration#fingerprint
       class NullManifest < Utils::BasicObject
         # Return a new instance
         #
@@ -83,8 +83,8 @@ module Hanami
 
         # Return a new instance
         #
-        # @param assets [Hash] the content of the digest manifest
-        # @param manifest_path [Pathname] the path to the digest manifest
+        # @param assets [Hash] the content of the manifest
+        # @param manifest_path [Pathname] the path to the manifest
         #
         # @return [Hanami::Assets::Config::Manifest] a new instance
         #
@@ -98,14 +98,14 @@ module Hanami
           @manifest_path = manifest_path
         end
 
-        # Resolve the given asset into a digest path
+        # Resolve the given asset into a fingerprinted path
         #
         # For a given path <tt>/assets/application.js</tt> it will return
         # <tt>/assets/application-28a6b886de2372ee3922fcaf3f78f2d8.js</tt>
         #
         # @param asset [#to_s] the relative asset path
         #
-        # @return [String] the digest path
+        # @return [String] the fingerprinted path
         #
         # @raise [Hanami::Assets::MissingManifestAssetError] when the asset can't be
         #   found in manifest

--- a/lib/hanami/assets/config/manifest.rb
+++ b/lib/hanami/assets/config/manifest.rb
@@ -44,12 +44,12 @@ module Hanami
       # @see Hanami::Assets::Configuration#manifest
       # @see Hanami::Assets::Configuration#manifest_path
       # @see Hanami::Assets::Configuration#digest
-      class NullDigestManifest < Utils::BasicObject
+      class NullManifest < Utils::BasicObject
         # Return a new instance
         #
         # @param configuration [Hanami::Assets::Configuration]
         #
-        # @return [Hanami::Assets::Config::NullDigestManifest] a new instance
+        # @return [Hanami::Assets::Config::NullManifest] a new instance
         #
         # @since 0.1.0
         # @api private
@@ -68,12 +68,12 @@ module Hanami
         end
       end
 
-      # Digest manifest
+      # Manifest file
       #
       # @since 0.1.0
       # @api private
-      class DigestManifest
-        # @since 0.3.0
+      class Manifest
+        # @since x.x.x
         # @api private
         TARGET                = 'target'.freeze
 

--- a/lib/hanami/assets/configuration.rb
+++ b/lib/hanami/assets/configuration.rb
@@ -506,7 +506,7 @@ module Hanami
         @compile               = false
         @base_url              = nil
         @destination_directory = nil
-        @digest_manifest       = Config::NullDigestManifest.new(self)
+        @digest_manifest       = Config::NullManifest.new(self)
 
         @javascript_compressor = nil
         @stylesheet_compressor = nil
@@ -523,8 +523,8 @@ module Hanami
       # @since 0.1.0
       def load!
         if (fingerprint || subresource_integrity) && manifest_path.exist?
-          @digest_manifest = Config::DigestManifest.new(
-            JSON.parse(manifest_path.read),
+          @digest_manifest = Config::Manifest.new(
+            JSON.load(manifest_path.read),
             manifest_path
           )
         end

--- a/lib/hanami/assets/configuration.rb
+++ b/lib/hanami/assets/configuration.rb
@@ -88,7 +88,7 @@ module Hanami
 
       # @since 0.1.0
       # @api private
-      attr_reader :digest_manifest
+      attr_reader :manifest
 
       # Return a new instance
       #
@@ -431,11 +431,11 @@ module Hanami
       # @since 0.3.0
       # @api private
       def subresource_integrity_value(source)
-        return unless subresource_integrity
-
-        digest_manifest.subresource_integrity_values(
-          prefix.join(source)
-        ).join(SUBRESOURCE_INTEGRITY_SEPARATOR)
+        if subresource_integrity
+          manifest.subresource_integrity_values(
+            prefix.join(source)
+          ).join(SUBRESOURCE_INTEGRITY_SEPARATOR)
+        end
       end
 
       # Load Javascript compressor
@@ -506,7 +506,7 @@ module Hanami
         @compile               = false
         @base_url              = nil
         @destination_directory = nil
-        @digest_manifest       = Config::NullManifest.new(self)
+        @manifest              = Config::NullManifest.new(self)
 
         @javascript_compressor = nil
         @stylesheet_compressor = nil
@@ -523,7 +523,7 @@ module Hanami
       # @since 0.1.0
       def load!
         if (fingerprint || subresource_integrity) && manifest_path.exist?
-          @digest_manifest = Config::Manifest.new(
+          @manifest = Config::Manifest.new(
             JSON.load(manifest_path.read),
             manifest_path
           )
@@ -592,7 +592,7 @@ module Hanami
       # @api private
       def compile_path(source)
         result = prefix.join(source)
-        result = digest_manifest.target(result) if fingerprint
+        result = manifest.target(result) if fingerprint
         result.to_s
       end
 

--- a/lib/hanami/assets/configuration.rb
+++ b/lib/hanami/assets/configuration.rb
@@ -115,7 +115,7 @@ module Hanami
         end
       end
 
-      # Digest mode
+      # Fingerprint mode
       #
       # Determine if the helpers should generate the fingerprinted path for an asset.
       # Usually this is turned on in production mode.

--- a/lib/hanami/assets/configuration.rb
+++ b/lib/hanami/assets/configuration.rb
@@ -345,11 +345,11 @@ module Hanami
       # Manifest path from public directory
       #
       # @since 0.1.0
-      def manifest(value = nil)
+      def manifest_name(value = nil)
         if value.nil?
-          @manifest
+          @manifest_name
         else
-          @manifest = value.to_s
+          @manifest_name = value.to_s
         end
       end
 
@@ -358,7 +358,7 @@ module Hanami
       # @since 0.1.0
       # @api private
       def manifest_path
-        public_directory.join(manifest)
+        public_directory.join(manifest_name)
       end
 
       # Application's assets sources
@@ -485,7 +485,7 @@ module Hanami
           c.cdn                   = cdn
           c.compile               = compile
           c.public_directory      = public_directory
-          c.manifest              = manifest
+          c.manifest_name         = manifest_name
           c.sources               = sources.dup
           c.javascript_compressor = javascript_compressor
           c.stylesheet_compressor = stylesheet_compressor
@@ -513,7 +513,7 @@ module Hanami
 
         root             Dir.pwd
         public_directory root.join(DEFAULT_PUBLIC_DIRECTORY)
-        manifest         DEFAULT_MANIFEST
+        manifest_name    DEFAULT_MANIFEST
       end
 
       # Load the configuration
@@ -572,7 +572,7 @@ module Hanami
 
       # @since 0.1.0
       # @api private
-      attr_writer :manifest
+      attr_writer :manifest_name
 
       # @since 0.1.0
       # @api private
@@ -592,7 +592,7 @@ module Hanami
       # @api private
       def compile_path(source)
         result = prefix.join(source)
-        result = manifest.target(result) if fingerprint
+        result = @manifest.target(result) if fingerprint
         result.to_s
       end
 

--- a/lib/hanami/assets/configuration.rb
+++ b/lib/hanami/assets/configuration.rb
@@ -117,15 +117,15 @@ module Hanami
 
       # Digest mode
       #
-      # Determine if the helpers should generate the digest path for an asset.
+      # Determine if the helpers should generate the fingerprinted path for an asset.
       # Usually this is turned on in production mode.
       #
       # @since 0.1.0
-      def digest(value = nil)
+      def fingerprint(value = nil)
         if value.nil?
-          @digest
+          @fingerprint
         else
-          @digest = value
+          @fingerprint = value
         end
       end
 
@@ -412,8 +412,8 @@ module Hanami
         "#{@base_url}#{compile_path(source)}"
       end
 
-      # An array of digest algorithms to use for generating asset subresource
-      # integrity checks
+      # An array of crypographically secure hashing algorithms to use for
+      # generating asset subresource integrity checks
       #
       # @since 0.3.0
       def subresource_integrity_algorithms
@@ -502,7 +502,7 @@ module Hanami
         @prefix                = Utils::PathPrefix.new(DEFAULT_PREFIX)
         @subresource_integrity = false
         @cdn                   = false
-        @digest                = false
+        @fingerprint           = false
         @compile               = false
         @base_url              = nil
         @destination_directory = nil
@@ -522,7 +522,7 @@ module Hanami
       #
       # @since 0.1.0
       def load!
-        if (digest || subresource_integrity) && manifest_path.exist?
+        if (fingerprint || subresource_integrity) && manifest_path.exist?
           @digest_manifest = Config::DigestManifest.new(
             JSON.parse(manifest_path.read),
             manifest_path
@@ -592,7 +592,7 @@ module Hanami
       # @api private
       def compile_path(source)
         result = prefix.join(source)
-        result = digest_manifest.target(result) if digest
+        result = digest_manifest.target(result) if fingerprint
         result.to_s
       end
 

--- a/lib/hanami/assets/configuration.rb
+++ b/lib/hanami/assets/configuration.rb
@@ -431,11 +431,11 @@ module Hanami
       # @since 0.3.0
       # @api private
       def subresource_integrity_value(source)
-        if subresource_integrity
-          manifest.subresource_integrity_values(
-            prefix.join(source)
-          ).join(SUBRESOURCE_INTEGRITY_SEPARATOR)
-        end
+        return unless subresource_integrity
+
+        manifest.subresource_integrity_values(
+          prefix.join(source)
+        ).join(SUBRESOURCE_INTEGRITY_SEPARATOR)
       end
 
       # Load Javascript compressor
@@ -524,7 +524,7 @@ module Hanami
       def load!
         if (fingerprint || subresource_integrity) && manifest_path.exist?
           @manifest = Config::Manifest.new(
-            JSON.load(manifest_path.read),
+            JSON.parse(manifest_path.read),
             manifest_path
           )
         end

--- a/lib/hanami/assets/helpers.rb
+++ b/lib/hanami/assets/helpers.rb
@@ -84,11 +84,15 @@ module Hanami
       # comes from the application or third party gems. It also accepts strings
       # representing absolute URLs in case of public CDN (eg. jQuery CDN).
       #
-      # If the "digest mode" is on, <tt>src</tt> is the digest version of the
-      # relative URL.
+      # If the "fingerprint mode" is on, <tt>src</tt> is the fingerprinted
+      # version of the relative URL.
       #
       # If the "CDN mode" is on, the <tt>src</tt> is an absolute URL of the
       # application CDN.
+      #
+      # If the "subresource integrity mode" is on, <tt>integriy</tt> is the
+      # name of the algorithm, then a hyphen, then the hash value of the file.
+      # If more than one algorithm is used, they'll be separated by a space.
       #
       # @param sources [Array<String>] one or more assets by name or absolute URL
       #
@@ -99,7 +103,7 @@ module Hanami
       #
       # @since 0.1.0
       #
-      # @see Hanami::Assets::Configuration#digest
+      # @see Hanami::Assets::Configuration#fingerprint
       # @see Hanami::Assets::Configuration#cdn
       # @see Hanami::Assets::Helpers#asset_path
       #
@@ -178,12 +182,15 @@ module Hanami
       # comes from the application or third party gems. It also accepts strings
       # representing absolute URLs in case of public CDN (eg. Bootstrap CDN).
       #
-      # If the "digest mode" is on, <tt>href</tt> is the digest version of the
-      # relative URL.
+      # If the "fingerprint mode" is on, <tt>href</tt> is the fingerprinted
+      # version of the relative URL.
       #
       # If the "CDN mode" is on, the <tt>href</tt> is an absolute URL of the
       # application CDN.
       #
+      # If the "subresource integrity mode" is on, <tt>integriy</tt> is the
+      # name of the algorithm, then a hyphen, then the hashed value of the file.
+      # If more than one algorithm is used, they'll be separated by a space.
       # @param sources [Array<String>] one or more assets by name or absolute URL
       #
       # @return [Hanami::Utils::Escape::SafeString] the markup
@@ -193,8 +200,9 @@ module Hanami
       #
       # @since 0.1.0
       #
-      # @see Hanami::Assets::Configuration#digest
+      # @see Hanami::Assets::Configuration#fingerprint
       # @see Hanami::Assets::Configuration#cdn
+      # @see Hanami::Assets::Configuration#subresource_integrity
       # @see Hanami::Assets::Helpers#asset_path
       #
       # @example Single Asset
@@ -264,8 +272,8 @@ module Hanami
       # <tt>alt</tt> Attribute is auto generated from <tt>src</tt>.
       # You can specify a different value, by passing the <tt>:src</tt> option.
       #
-      # If the "digest mode" is on, <tt>src</tt> is the digest version of the
-      # relative URL.
+      # If the "fingerprint mode" is on, <tt>src</tt> is the fingerprinted
+      # version of the relative URL.
       #
       # If the "CDN mode" is on, the <tt>src</tt> is an absolute URL of the
       # application CDN.
@@ -279,8 +287,9 @@ module Hanami
       #
       # @since 0.1.0
       #
-      # @see Hanami::Assets::Configuration#digest
+      # @see Hanami::Assets::Configuration#fingerprint
       # @see Hanami::Assets::Configuration#cdn
+      # @see Hanami::Assets::Configuration#subresource_integrity
       # @see Hanami::Assets::Helpers#asset_path
       #
       # @example Basic Usage
@@ -331,8 +340,8 @@ module Hanami
       #
       # It accepts one string representing the name of the asset.
       #
-      # If the "digest mode" is on, <tt>href</tt> is the digest version of the
-      # relative URL.
+      # If the "fingerprint mode" is on, <tt>href</tt> is the fingerprinted version
+      # of the relative URL.
       #
       # If the "CDN mode" is on, the <tt>href</tt> is an absolute URL of the
       # application CDN.
@@ -346,7 +355,7 @@ module Hanami
       #
       # @since 0.1.0
       #
-      # @see Hanami::Assets::Configuration#digest
+      # @see Hanami::Assets::Configuration#fingerprint
       # @see Hanami::Assets::Configuration#cdn
       # @see Hanami::Assets::Helpers#asset_path
       #
@@ -396,8 +405,8 @@ module Hanami
       # Alternatively, it accepts a block that allows to specify one or more
       # sources via the <tt>source</tt> tag.
       #
-      # If the "digest mode" is on, <tt>src</tt> is the digest version of the
-      # relative URL.
+      # If the "fingerprint mode" is on, <tt>src</tt> is the fingerprinted
+      # version of the relative URL.
       #
       # If the "CDN mode" is on, the <tt>src</tt> is an absolute URL of the
       # application CDN.
@@ -414,7 +423,7 @@ module Hanami
       #
       # @since 0.1.0
       #
-      # @see Hanami::Assets::Configuration#digest
+      # @see Hanami::Assets::Configuration#fingerprint
       # @see Hanami::Assets::Configuration#cdn
       # @see Hanami::Assets::Helpers#asset_path
       #
@@ -514,8 +523,8 @@ module Hanami
       # Alternatively, it accepts a block that allows to specify one or more
       # sources via the <tt>source</tt> tag.
       #
-      # If the "digest mode" is on, <tt>src</tt> is the digest version of the
-      # relative URL.
+      # If the "fingerprint mode" is on, <tt>src</tt> is the fingerprinted
+      # version of the relative URL.
       #
       # If the "CDN mode" is on, the <tt>src</tt> is an absolute URL of the
       # application CDN.
@@ -532,7 +541,7 @@ module Hanami
       #
       # @since 0.1.0
       #
-      # @see Hanami::Assets::Configuration#digest
+      # @see Hanami::Assets::Configuration#fingerprint
       # @see Hanami::Assets::Configuration#cdn
       # @see Hanami::Assets::Helpers#asset_path
       #
@@ -630,7 +639,7 @@ module Hanami
       #
       # Absolute URLs are returned as they are.
       #
-      # If Digest mode is on, it returns the digest path of the source
+      # If Fingerprint mode is on, it returns the fingerprinted path of the source
       #
       # If CDN mode is on, it returns the absolute URL of the asset.
       #
@@ -677,7 +686,7 @@ module Hanami
       #
       # Absolute URLs are returned as they are.
       #
-      # If Digest mode is on, it returns the digest URL of the source
+      # If Fingerprint mode is on, it returns the fingerprint URL of the source
       #
       # If CDN mode is on, it returns the absolute URL of the asset.
       #

--- a/lib/hanami/assets/helpers.rb
+++ b/lib/hanami/assets/helpers.rb
@@ -98,7 +98,7 @@ module Hanami
       #
       # @return [Hanami::Utils::Escape::SafeString] the markup
       #
-      # @raise [Hanami::Assets::MissingDigestAssetError] if digest mode is on and
+      # @raise [Hanami::Assets::MissingManifestAssetError] if digest mode is on and
       #   at least one of the given sources is missing from the manifest
       #
       # @since 0.1.0
@@ -195,7 +195,7 @@ module Hanami
       #
       # @return [Hanami::Utils::Escape::SafeString] the markup
       #
-      # @raise [Hanami::Assets::MissingDigestAssetError] if digest mode is on and
+      # @raise [Hanami::Assets::MissingManifestAssetError] if digest mode is on and
       #   at least one of the given sources is missing from the manifest
       #
       # @since 0.1.0
@@ -282,7 +282,7 @@ module Hanami
       #
       # @return [Hanami::Utils::Helpers::HtmlBuilder] the builder
       #
-      # @raise [Hanami::Assets::MissingDigestAssetError] if digest mode is on and
+      # @raise [Hanami::Assets::MissingManifestAssetError] if digest mode is on and
       #   the image is missing from the manifest
       #
       # @since 0.1.0
@@ -350,7 +350,7 @@ module Hanami
       #
       # @return [Hanami::Utils::Helpers::HtmlBuilder] the builder
       #
-      # @raise [Hanami::Assets::MissingDigestAssetError] if digest mode is on and
+      # @raise [Hanami::Assets::MissingManifestAssetError] if digest mode is on and
       #   the favicon is missing from the manifest
       #
       # @since 0.1.0
@@ -415,7 +415,7 @@ module Hanami
       #
       # @return [Hanami::Utils::Helpers::HtmlBuilder] the builder
       #
-      # @raise [Hanami::Assets::MissingDigestAssetError] if digest mode is on and
+      # @raise [Hanami::Assets::MissingManifestAssetError] if digest mode is on and
       #   the image is missing from the manifest
       #
       # @raise [ArgumentError] if source isn't specified both as argument or
@@ -533,7 +533,7 @@ module Hanami
       #
       # @return [Hanami::Utils::Helpers::HtmlBuilder] the builder
       #
-      # @raise [Hanami::Assets::MissingDigestAssetError] if digest mode is on and
+      # @raise [Hanami::Assets::MissingManifestAssetError] if digest mode is on and
       #   the image is missing from the manifest
       #
       # @raise [ArgumentError] if source isn't specified both as argument or
@@ -647,7 +647,7 @@ module Hanami
       #
       # @return [String] the asset path
       #
-      # @raise [Hanami::Assets::MissingDigestAssetError] if digest mode is on and
+      # @raise [Hanami::Assets::MissingManifestAssetError] if digest mode is on and
       #   the asset is missing from the manifest
       #
       # @since 0.1.0
@@ -694,7 +694,7 @@ module Hanami
       #
       # @return [String] the asset URL
       #
-      # @raise [Hanami::Assets::MissingDigestAssetError] if digest mode is on and
+      # @raise [Hanami::Assets::MissingManifestAssetError] if digest mode is on and
       #   the asset is missing from the manifest
       #
       # @since 0.1.0

--- a/lib/hanami/assets/helpers.rb
+++ b/lib/hanami/assets/helpers.rb
@@ -98,8 +98,9 @@ module Hanami
       #
       # @return [Hanami::Utils::Escape::SafeString] the markup
       #
-      # @raise [Hanami::Assets::MissingManifestAssetError] if digest mode is on and
-      #   at least one of the given sources is missing from the manifest
+      # @raise [Hanami::Assets::MissingManifestAssetError] if `fingerprint` or
+      # `subresource_integrity` modes are on and the javascript file is missing
+      # from the manifest
       #
       # @since 0.1.0
       #
@@ -150,7 +151,7 @@ module Hanami
       #
       #   # <script src="https://code.jquery.com/jquery-2.1.4.min.js" type="text/javascript"></script>
       #
-      # @example Digest Mode
+      # @example Fingerprint Mode
       #
       #   <%= javascript 'application' %>
       #
@@ -195,8 +196,9 @@ module Hanami
       #
       # @return [Hanami::Utils::Escape::SafeString] the markup
       #
-      # @raise [Hanami::Assets::MissingManifestAssetError] if digest mode is on and
-      #   at least one of the given sources is missing from the manifest
+      # @raise [Hanami::Assets::MissingManifestAssetError] if `fingerprint` or
+      # `subresource_integrity` modes are on and the stylesheet file is missing
+      # from the manifest
       #
       # @since 0.1.0
       #
@@ -236,7 +238,7 @@ module Hanami
       #
       #   # <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" type="text/css" rel="stylesheet">
       #
-      # @example Digest Mode
+      # @example Fingerprint Mode
       #
       #   <%= stylesheet 'application' %>
       #
@@ -282,8 +284,9 @@ module Hanami
       #
       # @return [Hanami::Utils::Helpers::HtmlBuilder] the builder
       #
-      # @raise [Hanami::Assets::MissingManifestAssetError] if digest mode is on and
-      #   the image is missing from the manifest
+      # @raise [Hanami::Assets::MissingManifestAssetError] if `fingerprint` or
+      # `subresource_integrity` modes are on and the image file is missing
+      # from the manifest
       #
       # @since 0.1.0
       #
@@ -316,7 +319,7 @@ module Hanami
       #
       #   # <img src="https://example-cdn.com/images/logo.png" alt="Logo">
       #
-      # @example Digest Mode
+      # @example Fingerprint Mode
       #
       #   <%= image 'logo.png' %>
       #
@@ -350,8 +353,9 @@ module Hanami
       #
       # @return [Hanami::Utils::Helpers::HtmlBuilder] the builder
       #
-      # @raise [Hanami::Assets::MissingManifestAssetError] if digest mode is on and
-      #   the favicon is missing from the manifest
+      # @raise [Hanami::Assets::MissingManifestAssetError] if `fingerprint` or
+      # `subresource_integrity` modes are on and the favicon is file missing
+      # from the manifest
       #
       # @since 0.1.0
       #
@@ -377,7 +381,7 @@ module Hanami
       #
       #   # <link id: "fav" href="/assets/favicon.ico" rel="shortcut icon" type="image/x-icon">
       #
-      # @example Digest Mode
+      # @example Fingerprint Mode
       #
       #   <%= favicon %>
       #
@@ -415,8 +419,9 @@ module Hanami
       #
       # @return [Hanami::Utils::Helpers::HtmlBuilder] the builder
       #
-      # @raise [Hanami::Assets::MissingManifestAssetError] if digest mode is on and
-      #   the image is missing from the manifest
+      # @raise [Hanami::Assets::MissingManifestAssetError] if `fingerprint` or
+      # `subresource_integrity` modes are on and the video file is missing
+      # from the manifest
       #
       # @raise [ArgumentError] if source isn't specified both as argument or
       #   tag inside the given block
@@ -498,7 +503,7 @@ module Hanami
       #
       #   # ArgumentError
       #
-      # @example Digest Mode
+      # @example Fingerprint Mode
       #
       #   <%= video 'movie.mp4' %>
       #
@@ -533,8 +538,9 @@ module Hanami
       #
       # @return [Hanami::Utils::Helpers::HtmlBuilder] the builder
       #
-      # @raise [Hanami::Assets::MissingManifestAssetError] if digest mode is on and
-      #   the image is missing from the manifest
+      # @raise [Hanami::Assets::MissingManifestAssetError] if `fingerprint` or
+      # `subresource_integrity` modes are on and the audio file is missing
+      # from the manifest
       #
       # @raise [ArgumentError] if source isn't specified both as argument or
       #   tag inside the given block
@@ -616,7 +622,7 @@ module Hanami
       #
       #   # ArgumentError
       #
-      # @example Digest Mode
+      # @example Fingerprint Mode
       #
       #   <%= audio 'song.ogg' %>
       #
@@ -647,8 +653,9 @@ module Hanami
       #
       # @return [String] the asset path
       #
-      # @raise [Hanami::Assets::MissingManifestAssetError] if digest mode is on and
-      #   the asset is missing from the manifest
+      # @raise [Hanami::Assets::MissingManifestAssetError] if `fingerprint` or
+      # `subresource_integrity` modes are on and the asset is missing
+      # from the manifest
       #
       # @since 0.1.0
       #
@@ -664,7 +671,7 @@ module Hanami
       #
       #   # "https://code.jquery.com/jquery-2.1.4.min.js"
       #
-      # @example Digest Mode
+      # @example Fingerprint Mode
       #
       #   <%= asset_path 'application.js' %>
       #
@@ -694,8 +701,9 @@ module Hanami
       #
       # @return [String] the asset URL
       #
-      # @raise [Hanami::Assets::MissingManifestAssetError] if digest mode is on and
-      #   the asset is missing from the manifest
+      # @raise [Hanami::Assets::MissingManifestAssetError] if `fingerprint` or
+      # `subresource_integrity` modes are on and the asset is missing
+      # from the manifest
       #
       # @since 0.1.0
       #
@@ -711,7 +719,7 @@ module Hanami
       #
       #   # "https://code.jquery.com/jquery-2.1.4.min.js"
       #
-      # @example Digest Mode
+      # @example Fingerprint Mode
       #
       #   <%= asset_url 'application.js' %>
       #

--- a/test/config/null_manifest_test.rb
+++ b/test/config/null_manifest_test.rb
@@ -1,9 +1,9 @@
 require 'test_helper'
 require 'pp'
 
-describe Hanami::Assets::Config::NullDigestManifest do
+describe Hanami::Assets::Config::NullManifest do
   let(:configuration) { Hanami::Assets::Configuration.new }
-  let(:manifest)      { Hanami::Assets::Config::NullDigestManifest.new(configuration) }
+  let(:manifest)      { Hanami::Assets::Config::NullManifest.new(configuration) }
 
   it 'is pretty printable' do
     pp manifest

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -272,12 +272,12 @@ describe Hanami::Assets::Configuration do
       actual.must_be_kind_of ::String
     end
 
-    describe 'digest mode' do
+    describe 'fingerprint mode' do
       before do
-        @configuration.digest true
+        @configuration.fingerprint true
       end
 
-      describe 'with digest manifest' do
+      describe 'with manifest' do
         before do
           manifest = Hanami::Assets::Config::DigestManifest.new({
                                                                   '/assets/application.js' => {
@@ -287,7 +287,7 @@ describe Hanami::Assets::Configuration do
           @configuration.instance_variable_set(:@digest_manifest, manifest)
         end
 
-        it 'returns asset with digest' do
+        it 'returns asset with fingerprint' do
           actual = @configuration.asset_path('application.js')
           actual.must_equal '/assets/application-abc123.js'
         end
@@ -309,8 +309,8 @@ describe Hanami::Assets::Configuration do
         end
       end
 
-      describe 'with missing digest manifest' do
-        it 'returns asset with digest' do
+      describe 'with missing manifest' do
+        it 'raises exception with correct message' do
           exception = -> { @configuration.asset_path('application.js') }.must_raise Hanami::Assets::MissingDigestManifestError
           exception.message.must_equal "Can't read manifest: #{@configuration.manifest_path}"
         end
@@ -436,12 +436,12 @@ describe Hanami::Assets::Configuration do
       end
     end
 
-    describe 'digest mode' do
+    describe 'fingerprint mode' do
       before do
-        @configuration.digest true
+        @configuration.fingerprint true
       end
 
-      describe 'with digest manifest' do
+      describe 'with manifest' do
         before do
           manifest = Hanami::Assets::Config::DigestManifest.new({ '/assets/application.js' => { 'target' => '/assets/application-abc123.js' } }, [])
 
@@ -449,14 +449,14 @@ describe Hanami::Assets::Configuration do
           @configuration.instance_variable_set(:@digest_manifest, manifest)
         end
 
-        it 'returns asset with digest' do
+        it 'returns asset with fingerprint' do
           actual = @configuration.asset_url('application.js')
           actual.must_equal 'http://localhost:2300/assets/application-abc123.js'
         end
       end
 
-      describe 'with missing digest manifest' do
-        it 'returns asset with digest' do
+      describe 'with missing manifest' do
+        it 'raises exception with correct message' do
           exception = -> { @configuration.asset_url('application.js') }.must_raise Hanami::Assets::MissingDigestManifestError
           exception.message.must_equal "Can't read manifest: #{@configuration.manifest_path}"
         end
@@ -470,7 +470,7 @@ describe Hanami::Assets::Configuration do
         @configuration.subresource_integrity true
       end
 
-      describe 'with digest manifest' do
+      describe 'with manifest' do
         before do
           manifest = Hanami::Assets::Config::DigestManifest.new({
                                                                   '/assets/application.js' => {
@@ -489,7 +489,7 @@ describe Hanami::Assets::Configuration do
         end
       end
 
-      describe 'with missing digest manifest' do
+      describe 'with missing manifest' do
         it 'raises an exception' do
           exception = -> { @configuration.subresource_integrity_value('application.js') }.must_raise Hanami::Assets::MissingDigestManifestError
           exception.message.must_equal "Can't read manifest: #{@configuration.manifest_path}"

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -280,10 +280,10 @@ describe Hanami::Assets::Configuration do
       describe 'with manifest' do
         before do
           manifest = Hanami::Assets::Config::Manifest.new({
-            '/assets/application.js' => {
-              'target' => '/assets/application-abc123.js'
-            }
-          }, [])
+                                                            '/assets/application.js' => {
+                                                              'target' => '/assets/application-abc123.js'
+                                                            }
+                                                          }, [])
           @configuration.instance_variable_set(:@manifest, manifest)
         end
 
@@ -473,11 +473,11 @@ describe Hanami::Assets::Configuration do
       describe 'with manifest' do
         before do
           manifest = Hanami::Assets::Config::Manifest.new({
-                                                                  '/assets/application.js' => {
-                                                                    'target' => '/assets/application-abc123.js',
-                                                                    'sri' => ['sha0-456def']
-                                                                  }
-                                                                }, [])
+                                                            '/assets/application.js' => {
+                                                              'target' => '/assets/application-abc123.js',
+                                                              'sri' => ['sha0-456def']
+                                                            }
+                                                          }, [])
 
           @configuration.load!
           @configuration.instance_variable_set(:@manifest, manifest)

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -279,11 +279,11 @@ describe Hanami::Assets::Configuration do
 
       describe 'with manifest' do
         before do
-          manifest = Hanami::Assets::Config::DigestManifest.new({
-                                                                  '/assets/application.js' => {
-                                                                    'target' => '/assets/application-abc123.js'
-                                                                  }
-                                                                }, [])
+          manifest = Hanami::Assets::Config::Manifest.new({
+            '/assets/application.js' => {
+              'target' => '/assets/application-abc123.js'
+            }
+          }, [])
           @configuration.instance_variable_set(:@digest_manifest, manifest)
         end
 
@@ -443,7 +443,7 @@ describe Hanami::Assets::Configuration do
 
       describe 'with manifest' do
         before do
-          manifest = Hanami::Assets::Config::DigestManifest.new({ '/assets/application.js' => { 'target' => '/assets/application-abc123.js' } }, [])
+          manifest = Hanami::Assets::Config::Manifest.new({ '/assets/application.js' => { 'target' => '/assets/application-abc123.js' } }, [])
 
           @configuration.load!
           @configuration.instance_variable_set(:@digest_manifest, manifest)
@@ -472,7 +472,7 @@ describe Hanami::Assets::Configuration do
 
       describe 'with manifest' do
         before do
-          manifest = Hanami::Assets::Config::DigestManifest.new({
+          manifest = Hanami::Assets::Config::Manifest.new({
                                                                   '/assets/application.js' => {
                                                                     'target' => '/assets/application-abc123.js',
                                                                     'sri' => ['sha0-456def']
@@ -547,8 +547,8 @@ describe Hanami::Assets::Configuration do
     end
 
     it 'sets default value fore digest manifest' do
-      assert @configuration.digest_manifest.class == Hanami::Assets::Config::NullDigestManifest,
-             'Expected @configuration.digest_manifest to be instance of Hanami::Assets::Configuration::NullDigestManifest'
+      assert @configuration.digest_manifest.class == Hanami::Assets::Config::NullManifest,
+             'Expected @configuration.digest_manifest to be instance of Hanami::Assets::Configuration::NullManifest'
     end
   end
 

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -284,7 +284,7 @@ describe Hanami::Assets::Configuration do
               'target' => '/assets/application-abc123.js'
             }
           }, [])
-          @configuration.instance_variable_set(:@digest_manifest, manifest)
+          @configuration.instance_variable_set(:@manifest, manifest)
         end
 
         it 'returns asset with fingerprint' do
@@ -446,7 +446,7 @@ describe Hanami::Assets::Configuration do
           manifest = Hanami::Assets::Config::Manifest.new({ '/assets/application.js' => { 'target' => '/assets/application-abc123.js' } }, [])
 
           @configuration.load!
-          @configuration.instance_variable_set(:@digest_manifest, manifest)
+          @configuration.instance_variable_set(:@manifest, manifest)
         end
 
         it 'returns asset with fingerprint' do
@@ -480,7 +480,7 @@ describe Hanami::Assets::Configuration do
                                                                 }, [])
 
           @configuration.load!
-          @configuration.instance_variable_set(:@digest_manifest, manifest)
+          @configuration.instance_variable_set(:@manifest, manifest)
         end
 
         it 'returns subresource_integrity value' do
@@ -508,7 +508,7 @@ describe Hanami::Assets::Configuration do
       @configuration.stylesheet_compressor :yui
       @configuration.manifest 'assets.json'
       @configuration.public_directory(Dir.pwd + '/tmp')
-      @configuration.instance_variable_set(:@digest_manifest, {})
+      @configuration.instance_variable_set(:@manifest, {})
 
       @configuration.reset!
     end
@@ -547,8 +547,8 @@ describe Hanami::Assets::Configuration do
     end
 
     it 'sets default value fore digest manifest' do
-      assert @configuration.digest_manifest.class == Hanami::Assets::Config::NullManifest,
-             'Expected @configuration.digest_manifest to be instance of Hanami::Assets::Configuration::NullManifest'
+      assert @configuration.manifest.class == Hanami::Assets::Config::NullManifest,
+             'Expected @configuration.manifest to be instance of Hanami::Assets::Configuration::NullManifest'
     end
   end
 

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -546,7 +546,7 @@ describe Hanami::Assets::Configuration do
       @configuration.manifest.must_equal('assets.json')
     end
 
-    it 'sets default value fore digest manifest' do
+    it 'sets default value for manifest' do
       assert @configuration.manifest.class == Hanami::Assets::Config::NullManifest,
              'Expected @configuration.manifest to be instance of Hanami::Assets::Configuration::NullManifest'
     end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -234,25 +234,25 @@ describe Hanami::Assets::Configuration do
     end
   end
 
-  describe '#manifest' do
+  describe '#manifest_name' do
     it 'defaults to "assets.json"' do
-      @configuration.manifest.must_equal 'assets.json'
+      @configuration.manifest_name.must_equal 'assets.json'
     end
 
     it 'allows to set a relative path' do
-      @configuration.manifest            'manifest.json'
-      @configuration.manifest.must_equal 'manifest.json'
+      @configuration.manifest_name            'manifest.json'
+      @configuration.manifest_name.must_equal 'manifest.json'
     end
   end
 
   describe '#manifest_path' do
     it 'joins #manifest with #public_directory' do
-      expected = @configuration.public_directory.join(@configuration.manifest)
+      expected = @configuration.public_directory.join(@configuration.manifest_name)
       @configuration.manifest_path.must_equal expected
     end
 
     it 'returns absolute path, if #manifest is absolute path' do
-      @configuration.manifest expected = __dir__ + '/manifest.json'
+      @configuration.manifest_name expected = __dir__ + '/manifest.json'
       @configuration.manifest_path.must_equal Pathname.new(expected)
     end
   end
@@ -506,7 +506,7 @@ describe Hanami::Assets::Configuration do
       @configuration.prefix 'prfx'
       @configuration.javascript_compressor :yui
       @configuration.stylesheet_compressor :yui
-      @configuration.manifest 'assets.json'
+      @configuration.manifest_name 'assets.json'
       @configuration.public_directory(Dir.pwd + '/tmp')
       @configuration.instance_variable_set(:@manifest, {})
 
@@ -543,7 +543,7 @@ describe Hanami::Assets::Configuration do
     end
 
     it 'sets default value for manifest' do
-      @configuration.manifest.must_equal('assets.json')
+      @configuration.manifest_name.must_equal('assets.json')
     end
 
     it 'sets default value for manifest' do
@@ -562,7 +562,7 @@ describe Hanami::Assets::Configuration do
       @configuration.host                  'hanamirb.org'
       @configuration.port                  '8080'
       @configuration.prefix                '/foo'
-      @configuration.manifest              'm.json'
+      @configuration.manifest_name         'm.json'
       @configuration.javascript_compressor :yui
       @configuration.stylesheet_compressor :yui
       @configuration.root                  __dir__
@@ -580,7 +580,7 @@ describe Hanami::Assets::Configuration do
       @config.host.must_equal                  'hanamirb.org'
       @config.port.must_equal                  '8080'
       @config.prefix.must_equal                '/foo'
-      @config.manifest.must_equal              'm.json'
+      @config.manifest_name.must_equal         'm.json'
       @config.javascript_compressor.must_equal :yui
       @config.stylesheet_compressor.must_equal :yui
       @config.root.must_equal                  Pathname.new(__dir__)
@@ -597,7 +597,7 @@ describe Hanami::Assets::Configuration do
       @config.host                  'example.org'
       @config.port                  '9091'
       @config.prefix                '/bar'
-      @config.manifest              'a.json'
+      @config.manifest_name         'a.json'
       @config.javascript_compressor :uglify
       @config.stylesheet_compressor :uglify
       @config.root                  __dir__ + '/fixtures'
@@ -611,7 +611,7 @@ describe Hanami::Assets::Configuration do
       @config.host.must_equal                  'example.org'
       @config.port.must_equal                  '9091'
       @config.prefix.must_equal                '/bar'
-      @config.manifest.must_equal              'a.json'
+      @config.manifest_name.must_equal         'a.json'
       @config.javascript_compressor.must_equal :uglify
       @config.stylesheet_compressor.must_equal :uglify
       @config.root.must_equal                  Pathname.new(__dir__ + '/fixtures')
@@ -626,7 +626,7 @@ describe Hanami::Assets::Configuration do
       @configuration.host.must_equal                  'hanamirb.org'
       @configuration.port.must_equal                  '8080'
       @configuration.prefix.must_equal                '/foo'
-      @configuration.manifest.must_equal              'm.json'
+      @configuration.manifest_name.must_equal         'm.json'
       @configuration.javascript_compressor.must_equal :yui
       @configuration.stylesheet_compressor.must_equal :yui
       @configuration.root.must_equal                  Pathname.new(__dir__)

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -311,7 +311,7 @@ describe Hanami::Assets::Configuration do
 
       describe 'with missing manifest' do
         it 'raises exception with correct message' do
-          exception = -> { @configuration.asset_path('application.js') }.must_raise Hanami::Assets::MissingDigestManifestError
+          exception = -> { @configuration.asset_path('application.js') }.must_raise Hanami::Assets::MissingManifestFileError
           exception.message.must_equal "Can't read manifest: #{@configuration.manifest_path}"
         end
       end
@@ -457,7 +457,7 @@ describe Hanami::Assets::Configuration do
 
       describe 'with missing manifest' do
         it 'raises exception with correct message' do
-          exception = -> { @configuration.asset_url('application.js') }.must_raise Hanami::Assets::MissingDigestManifestError
+          exception = -> { @configuration.asset_url('application.js') }.must_raise Hanami::Assets::MissingManifestFileError
           exception.message.must_equal "Can't read manifest: #{@configuration.manifest_path}"
         end
       end
@@ -491,7 +491,7 @@ describe Hanami::Assets::Configuration do
 
       describe 'with missing manifest' do
         it 'raises an exception' do
-          exception = -> { @configuration.subresource_integrity_value('application.js') }.must_raise Hanami::Assets::MissingDigestManifestError
+          exception = -> { @configuration.subresource_integrity_value('application.js') }.must_raise Hanami::Assets::MissingManifestFileError
           exception.message.must_equal "Can't read manifest: #{@configuration.manifest_path}"
         end
       end

--- a/test/fixtures/bookshelf/config/environment.rb
+++ b/test/fixtures/bookshelf/config/environment.rb
@@ -25,7 +25,7 @@ unless defined?(Web)
     Assets = Hanami::Assets.duplicate(self) do
       root             __dir__ + '/../../../fixtures/bookshelf/apps/admin'
       public_directory __dir__ + '/../../../../tmp/bookshelf/public'
-      manifest         'assets.json'
+      manifest_name    'assets.json'
       prefix           '/assets/admin'
       compile          true
 
@@ -60,7 +60,7 @@ unless defined?(Web)
     Assets = Hanami::Assets.duplicate(self) do
       root             __dir__ + '/../../../fixtures/bookshelf/apps/metrics'
       public_directory __dir__ + '/../../../../tmp/bookshelf/public'
-      manifest         'assets.json'
+      manifest_name    'assets.json'
       prefix           '/assets/metrics'
       compile          true
 
@@ -95,7 +95,7 @@ unless defined?(Web)
     Assets = Hanami::Assets.duplicate(self) do
       root             __dir__ + '/../../../fixtures/bookshelf/apps/web'
       public_directory __dir__ + '/../../../../tmp/bookshelf/public'
-      manifest         'assets.json'
+      manifest_name    'assets.json'
       prefix           '/assets'
       compile          true
 

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -369,17 +369,17 @@ describe Hanami::Assets::Helpers do
     view.class.assets_configuration.load!
 
     manifest = Hanami::Assets::Config::Manifest.new({
-                                                            '/assets/feature-a.js' => {
-                                                              'sri' => [
-                                                                'sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC'
-                                                              ]
-                                                            },
-                                                            '/assets/main.css' => {
-                                                              'sri' => [
-                                                                'sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC'
-                                                              ]
-                                                            }
-                                                          }, [])
+                                                      '/assets/feature-a.js' => {
+                                                        'sri' => [
+                                                          'sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC'
+                                                        ]
+                                                      },
+                                                      '/assets/main.css' => {
+                                                        'sri' => [
+                                                          'sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC'
+                                                        ]
+                                                      }
+                                                    }, [])
     view.class.assets_configuration.instance_variable_set(:@manifest, manifest)
   end
 

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -368,7 +368,7 @@ describe Hanami::Assets::Helpers do
     view.class.assets_configuration.subresource_integrity true
     view.class.assets_configuration.load!
 
-    manifest = Hanami::Assets::Config::DigestManifest.new({
+    manifest = Hanami::Assets::Config::Manifest.new({
                                                             '/assets/feature-a.js' => {
                                                               'sri' => [
                                                                 'sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC'

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -380,7 +380,7 @@ describe Hanami::Assets::Helpers do
                                                               ]
                                                             }
                                                           }, [])
-    view.class.assets_configuration.instance_variable_set(:@digest_manifest, manifest)
+    view.class.assets_configuration.instance_variable_set(:@manifest, manifest)
   end
 
   def activate_cdn_mode! # rubocop:disable Metrics/AbcSize

--- a/test/integration/fingerprint_test.rb
+++ b/test/integration/fingerprint_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-describe 'Digest mode' do
+describe 'Fingerprint mode' do
   before do
     dest.rmtree if dest.exist?
     dest.mkpath
@@ -11,14 +11,14 @@ describe 'Digest mode' do
     frameworks = [Web::Assets, Admin::Assets]
     frameworks.each do |framework|
       framework.configure do
-        digest true
+        fingerprint true
       end.load!
     end
   end
 
   let(:dest) { TMP.join('bookshelf', 'public') }
 
-  it 'uses digest relative urls' do
+  it 'uses fingerprinted relative urls' do
     rendered = Web::Views::Books::Show.render(format: :html)
     rendered.must_match %(<script src="/assets/jquery-05277a4edea56b7f82a4c1442159e183.js" type="text/javascript"></script>)
     rendered.must_match %(<script src="/assets/application-d1829dc353b734e3adc24855693b70f9.js" type="text/javascript"></script>)

--- a/test/integration/fingerprint_test.rb
+++ b/test/integration/fingerprint_test.rb
@@ -25,7 +25,7 @@ describe 'Fingerprint mode' do
   end
 
   it 'raises error when referencing missing asset' do
-    exception = -> { Web::Views::Users::Show.render(format: :html) }.must_raise(Hanami::Assets::MissingDigestAssetError)
+    exception = -> { Web::Views::Users::Show.render(format: :html) }.must_raise(Hanami::Assets::MissingManifestAssetError)
     exception.message.must_equal "Can't find asset `/assets/missing.js' in manifest (#{Hanami::Assets.configuration.manifest_path})"
   end
 end

--- a/test/integration/precompile_test.rb
+++ b/test/integration/precompile_test.rb
@@ -48,13 +48,13 @@ describe 'Precompile' do
         vendor_files.each { |f| f.exist?.must_equal true }
       end
 
-      it "doesn't creates a digest version" do
+      it "doesn't creates a fingerprinted version" do
         vendor_files.each { |file| FileUtils.touch file }
         assert_successful_command environment
 
         vendor_files.each do |f|
-          digest_versions = Dir[dest.join("#{f.basename(f.extname)}-*#{f.extname}").to_s]
-          digest_versions.must_be :empty?
+          fingerprinted_versions = Dir[dest.join("#{f.basename(f.extname)}-*#{f.extname}").to_s]
+          fingerprinted_versions.must_be :empty?
         end
       end
     end
@@ -109,13 +109,13 @@ describe 'Precompile' do
         vendor_files.each { |f| f.exist?.must_equal true }
       end
 
-      it "doesn't creates a digest version" do
+      it "doesn't creates a fingerprinted version" do
         vendor_files.each { |file| FileUtils.touch file }
         assert_successful_command environment
 
         vendor_files.each do |f|
-          digest_versions = Dir[dest.join("#{f.basename(f.extname)}-*#{f.extname}").to_s]
-          digest_versions.must_be :empty?
+          fingerprinted_versions = Dir[dest.join("#{f.basename(f.extname)}-*#{f.extname}").to_s]
+          fingerprinted_versions.must_be :empty?
         end
       end
     end

--- a/test/integration/view_test.rb
+++ b/test/integration/view_test.rb
@@ -6,7 +6,7 @@ describe 'Hanami::View integration' do
     frameworks = [Web::Assets, Admin::Assets]
     frameworks.each do |framework|
       framework.configure do
-        digest false
+        fingerprint false
       end
     end
   end


### PR DESCRIPTION
We refer to the feature that adds cache-busters as `digest`ing, which is a pretty vague term since it's the output of a hash function. Since we've added Subresource Integrity, we have hash 'digests' there too, using different algorithms in for a different (related) feature.

Instead, I think we should refer to `digest` as `fingerprint` instead. This change implements that. (I also added some Subresource Integrity documentation in a couple places).

This has little effect on users, since it's just changing one word to another. I think it helps improve maintainability of this framework though, since it gives more distinct, descriptive names. (Which helps users when they read the source of the framework, to understand what it's doing).

I'd like to get this change into `hanami v0.8.0` if possible.
This would be a breaking change, since it requires changing the name of the config option from `digest` to `fingerprint`. Could this be `hanami-assets v0.4.0` and have `hanami v0.8.0` depend on it?

(I'm getting errors in the tests locally, but I'm not sure if that's related to Java. If there are actual failing tests, I'll fix them tomorrow morning).
