### PR TITLE
Compile files with dots in their names

### DIFF
--- a/lib/hanami/assets/compiler.rb
+++ b/lib/hanami/assets/compiler.rb
@@ -35,7 +35,7 @@ module Hanami
 
       # @since 0.1.0
       # @api private
-      COMPILE_PATTERN = '*.*.*'.freeze # Example hello.js.es6
+      COMPILE_PATTERN = /.*[.].*[.].*/ # Example hello.js.es6 or hello.core.js.es6
 
       # @since 0.1.0
       # @api private
@@ -157,7 +157,7 @@ module Hanami
         result = ::File.basename(@name)
 
         if compile?
-          result.scan(/\A[[[:alnum:]][\-\_]]*\.[[\w]]*/).first || result
+          result.scan(/\A[[[:alnum:]][\-\_].]*\.[[\w]]*/).first || result
         else
           result
         end
@@ -180,7 +180,7 @@ module Hanami
       # @since 0.1.0
       # @api private
       def compile?
-        @compile ||= ::File.fnmatch(COMPILE_PATTERN, ::File.basename(source.to_s)) &&
+        @compile ||= COMPILE_PATTERN.match(::File.basename(source.to_s)) &&
                      !EXTENSIONS[::File.extname(source.to_s)]
       end
 

--- a/test/fixtures/javascripts/person.foo.bar.js.es6
+++ b/test/fixtures/javascripts/person.foo.bar.js.es6
@@ -1,0 +1,10 @@
+class Person {
+  constructor(firstName, lastName) {
+    this.firstName = firstName;
+    this.lastName  = lastName;
+  }
+
+  get name() {
+    return "#{ this.firstName } #{ this.lastName }";
+  }
+}

--- a/test/integration/compiler_test.rb
+++ b/test/integration/compiler_test.rb
@@ -85,6 +85,14 @@ describe 'Compiler' do
     target.stat.mode.to_s(8).must_equal('100644')
   end
 
+  it 'compiles assets with dots in name' do
+    Hanami::Assets::Compiler.compile(@config, 'person.foo.bar.js')
+
+    target = @config.public_directory.join('assets', 'person.foo.bar.js')
+    target.read.must_match %(function Person(firstName, lastName))
+    target.stat.mode.to_s(8).must_equal('100644')
+  end
+
   it 'compiles sass asset' do
     Hanami::Assets::Compiler.compile(@config, 'compile-sass.css')
 


### PR DESCRIPTION
Compile files that have dots in their name unrelated to the file extension. Zurb Foundation uses this pattern (e.g. foundation.core.js.es6)