### PR TITLE
Fix issues with testing on Linux

### DIFF
--- a/lib/hanami/assets/config/sources.rb
+++ b/lib/hanami/assets/config/sources.rb
@@ -1,4 +1,5 @@
 require 'hanami/utils/load_paths'
+require 'hanami/utils/file_list'
 
 module Hanami
   module Assets
@@ -55,7 +56,7 @@ module Hanami
         def files(name = nil)
           result = []
 
-          Dir.glob(map { |source| "#{source}#{::File::SEPARATOR}**#{::File::SEPARATOR}#{name}*" }).each do |file|
+          Utils::FileList[map { |source| "#{source}#{::File::SEPARATOR}**#{::File::SEPARATOR}#{name}*" }].each do |file|
             next if ::File.directory?(file) || ::File.basename(file).start_with?(SKIPPED_FILE_PREFIX)
             result << file
           end

--- a/test/support/test_file.rb
+++ b/test/support/test_file.rb
@@ -17,7 +17,7 @@ class TestFile
   def touch(content = nil)
     last_modified = mtime
 
-    while mtime <= last_modified
+    while mtime.to_i <= last_modified.to_i
       wait 1
       write(content)
     end


### PR DESCRIPTION
* Use Utils::FileList instead of Dir.glob to ensure order - Entries order cannot be guaranteed when using Dir.glob, causing random errors while running on some filesystems. Utils::FileList is OS-independent and guarantees order, hence using it is much better option.
* Compare timestamps instead of dates - When comparing dates (on open file, I presume) the comparison with `<=` shows that dates are different, even though difference is on a sub-second level. As a result, when comparing later, mtimes of both times are the same, leading at least tests to fail. The workaround is to cast both dates to timestamp using `#to_i` before comparison.

This addresses #73 

With those changes, maybe it might be possible to remove those `if CI.enabled?` statements, although I havent' checked that yet.