### PR TITLE
Fix/helpers do not append ext after URI query string

### DIFF
--- a/lib/hanami/assets/helpers.rb
+++ b/lib/hanami/assets/helpers.rb
@@ -62,6 +62,10 @@ module Hanami
       # @api private
       ABSOLUTE_URL_MATCHER = URI::DEFAULT_PARSER.make_regexp
 
+      # @since 1.1.0
+      # @api private
+      QUERY_STRING_MATCHER = /\?/
+
       include Hanami::Helpers::HtmlHelper
 
       # Inject helpers into the given class
@@ -758,7 +762,7 @@ module Hanami
       # @since 0.1.0
       # @api private
       def _typed_asset_path(source, ext)
-        source = "#{source}#{ext}" unless source =~ /#{Regexp.escape(ext)}\z/
+        source = "#{source}#{ext}" if _append_extension?(source, ext)
         asset_path(source)
       end
 
@@ -818,6 +822,12 @@ module Hanami
         end
 
         url
+      end
+
+      # @since 1.1.0
+      # @api private
+      def _append_extension?(source, ext)
+        source !~ QUERY_STRING_MATCHER && source !~ /#{Regexp.escape(ext)}\z/
       end
     end
   end

--- a/spec/unit/hanami/assets/helpers_spec.rb
+++ b/spec/unit/hanami/assets/helpers_spec.rb
@@ -17,6 +17,11 @@ describe Hanami::Assets::Helpers do
       expect(actual).to eq(%(<script src="/assets/feature-a.js" type="text/javascript"></script>))
     end
 
+    it 'renders <script> tag without appending ext after query string' do
+      actual = DefaultView.new.javascript('feature-x?callback=init')
+      expect(actual).to eq(%(<script src="/assets/feature-x?callback=init" type="text/javascript"></script>))
+    end
+
     it 'renders <script> tag with a defer attribute' do
       actual = DefaultView.new.javascript('feature-a', defer: true)
       expect(actual).to eq(%(<script defer="defer" src="/assets/feature-a.js" type="text/javascript"></script>))
@@ -76,6 +81,11 @@ describe Hanami::Assets::Helpers do
     it 'renders <link> tag' do
       actual = DefaultView.new.stylesheet('main')
       expect(actual).to eq(%(<link href="/assets/main.css" type="text/css" rel="stylesheet">))
+    end
+
+    it 'renders <link> tag without appending ext after query string' do
+      actual = DefaultView.new.stylesheet('fonts?font=Helvetica')
+      expect(actual).to eq(%(<link href="/assets/fonts?font=Helvetica" type="text/css" rel="stylesheet">))
     end
 
     it 'renders <link> tag with an integrity attribute' do


### PR DESCRIPTION
Don't append file extension when the given URI has a query string.

```erb
<%= javascript "foo?callback=init" %>
```

Must return:

```html
<script src="/assets/foo?callback=init" type="text/javascript"></script>
```

It used to return wrong `src`:

```html
<script src="/assets/foo?callback=init.js" type="text/javascript"></script>
```

---

Fixes #83 