### PR TITLE
Enhance Push Promise/Early Hints registry

### DIFF
--- a/lib/hanami/assets/configuration.rb
+++ b/lib/hanami/assets/configuration.rb
@@ -412,6 +412,18 @@ module Hanami
         "#{@base_url}#{compile_path(source)}"
       end
 
+      # Check if the given source is linked via Cross-Origin policy.
+      # In other words, the given source, doesn't satisfy the Same-Origin policy.
+      #
+      # @see https://en.wikipedia.org/wiki/Same-origin_policy#Origin_determination_rules
+      # @see https://en.wikipedia.org/wiki/Same-origin_policy#document.domain_property
+      #
+      # @since x.x.x
+      # @api private
+      def crossorigin?(source)
+        !source.start_with?(@base_url)
+      end
+
       # An array of crypographically secure hashing algorithms to use for
       # generating asset subresource integrity checks
       #

--- a/lib/hanami/assets/helpers.rb
+++ b/lib/hanami/assets/helpers.rb
@@ -96,7 +96,11 @@ module Hanami
       # name of the algorithm, then a hyphen, then the hash value of the file.
       # If more than one algorithm is used, they'll be separated by a space.
       #
+      # It makes the script(s) eligible for HTTP/2 Push Promise/Early Hints.
+      # You can opt-out with inline option: `push: false`.
+      #
       # @param sources [Array<String>] one or more assets by name or absolute URL
+      # @param push [TrueClass, FalseClass] HTTP/2 Push Promise/Early Hints flag
       #
       # @return [Hanami::Utils::Escape::SafeString] the markup
       #
@@ -164,6 +168,11 @@ module Hanami
       #   <%= javascript 'application' %>
       #
       #   # <script src="https://assets.bookshelf.org/assets/application-28a6b886de2372ee3922fcaf3f78f2d8.js" type="text/javascript"></script>
+      #
+      # @example Disable Push Promise/Early Hints
+      #
+      #   <%= javascript 'application', push: false %>
+      #   <%= javascript 'http://cdn.example.test/jquery.js', 'dashboard', push: false %>
       def javascript(*sources, push: true, **options)
         _safe_tags(*sources) do |source|
           tag_options = options.dup
@@ -194,7 +203,12 @@ module Hanami
       # If the "subresource integrity mode" is on, <tt>integriy</tt> is the
       # name of the algorithm, then a hyphen, then the hashed value of the file.
       # If more than one algorithm is used, they'll be separated by a space.
+      #
+      # It makes the script(s) eligible for HTTP/2 Push Promise/Early Hints.
+      # You can opt-out with inline option: `push: false`.
+      #
       # @param sources [Array<String>] one or more assets by name or absolute URL
+      # @param push [TrueClass, FalseClass] HTTP/2 Push Promise/Early Hints flag
       #
       # @return [Hanami::Utils::Escape::SafeString] the markup
       #
@@ -251,6 +265,11 @@ module Hanami
       #   <%= stylesheet 'application' %>
       #
       #   # <link href="https://assets.bookshelf.org/assets/application-28a6b886de2372ee3922fcaf3f78f2d8.css" type="text/css" rel="stylesheet">
+      #
+      # @example Disable Push Promise/Early Hints
+      #
+      #   <%= stylesheet 'application', push: false %>
+      #   <%= stylesheet 'http://cdn.example.test/bootstrap.css', 'dashboard', push: false %>
       def stylesheet(*sources, push: true, **options) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
         _safe_tags(*sources) do |source|
           tag_options = options.dup
@@ -283,6 +302,8 @@ module Hanami
       # application CDN.
       #
       # @param source [String] asset name or absolute URL
+      # @param options [Hash] HTML 5 attributes
+      # @option options [TrueClass, FalseClass] :push HTTP/2 Push Promise/Early Hints flag
       #
       # @return [Hanami::Utils::Helpers::HtmlBuilder] the builder
       #
@@ -332,6 +353,10 @@ module Hanami
       #   <%= image 'logo.png' %>
       #
       #   # <img src="https://assets.bookshelf.org/assets/logo-28a6b886de2372ee3922fcaf3f78f2d8.png" alt="Logo">
+      #
+      # @example Enable Push Promise/Early Hints
+      #
+      #   <%= image 'logo.png', push: true %>
       def image(source, options = {})
         options[:src] = asset_path(source, push: options.delete(:push) || false, as: :image)
         options[:alt] ||= Utils::String.titleize(::File.basename(source, WILDCARD_EXT))
@@ -352,6 +377,8 @@ module Hanami
       # application CDN.
       #
       # @param source [String] asset name
+      # @param options [Hash] HTML 5 attributes
+      # @option options [TrueClass, FalseClass] :push HTTP/2 Push Promise/Early Hints flag
       #
       # @return [Hanami::Utils::Helpers::HtmlBuilder] the builder
       #
@@ -394,6 +421,10 @@ module Hanami
       #   <%= favicon %>
       #
       #   # <link href="https://assets.bookshelf.org/assets/favicon-28a6b886de2372ee3922fcaf3f78f2d8.ico" rel="shortcut icon" type="image/x-icon">
+      #
+      # @example Enable Push Promise/Early Hints
+      #
+      #   <%= favicon 'favicon.ico', push: true %>
       def favicon(source = DEFAULT_FAVICON, options = {})
         options[:href]   = asset_path(source, push: options.delete(:push) || false, as: :image)
         options[:rel]  ||= FAVICON_REL
@@ -418,6 +449,8 @@ module Hanami
       # application CDN.
       #
       # @param source [String] asset name or absolute URL
+      # @param options [Hash] HTML 5 attributes
+      # @option options [TrueClass, FalseClass] :push HTTP/2 Push Promise/Early Hints flag
       #
       # @return [Hanami::Utils::Helpers::HtmlBuilder] the builder
       #
@@ -516,6 +549,18 @@ module Hanami
       #   <%= video 'movie.mp4' %>
       #
       #   # <video src="https://assets.bookshelf.org/assets/movie-28a6b886de2372ee3922fcaf3f78f2d8.mp4"></video>
+      #
+      # @example Enable Push Promise/Early Hints
+      #
+      #   <%= video 'movie.mp4', push: true %>
+      #
+      # <%=
+      #   video do
+      #     text "Your browser does not support the video tag"
+      #     source src: asset_path("movie.mp4", push: :video), type: "video/mp4"
+      #     source src: asset_path("movie.ogg"), type: "video/ogg"
+      #   end
+      # %>
       def video(source = nil, options = {}, &blk)
         options = _source_options(source, options, as: :video, &blk)
         html.video(blk, options)
@@ -537,6 +582,8 @@ module Hanami
       # application CDN.
       #
       # @param source [String] asset name or absolute URL
+      # @param options [Hash] HTML 5 attributes
+      # @option options [TrueClass, FalseClass] :push HTTP/2 Push Promise/Early Hints flag
       #
       # @return [Hanami::Utils::Helpers::HtmlBuilder] the builder
       #
@@ -635,6 +682,18 @@ module Hanami
       #   <%= audio 'song.ogg' %>
       #
       #   # <audio src="https://assets.bookshelf.org/assets/song-28a6b886de2372ee3922fcaf3f78f2d8.ogg"></audio>
+      #
+      # @example Enable Push Promise/Early Hints
+      #
+      #   <%= audio 'movie.mp4', push: true %>
+      #
+      # <%=
+      #   audio do
+      #     text "Your browser does not support the audio tag"
+      #     source src: asset_path("song.ogg", push: :audio), type: "audio/ogg"
+      #     source src: asset_path("song.wav"), type: "audio/wav"
+      #   end
+      # %>
       def audio(source = nil, options = {}, &blk)
         options = _source_options(source, options, as: :audio, &blk)
         html.audio(blk, options)
@@ -652,6 +711,8 @@ module Hanami
       # If CDN mode is on, it returns the absolute URL of the asset.
       #
       # @param source [String] the asset name
+      # @param push [TrueClass, FalseClass, Symbol] HTTP/2 Push Promise/Early Hints flag, or type
+      # @param as [Symbol] HTTP/2 Push Promise / Early Hints flag type
       #
       # @return [String] the asset path
       #
@@ -684,6 +745,10 @@ module Hanami
       #   <%= asset_path 'application.js' %>
       #
       #   # "https://assets.bookshelf.org/assets/application-28a6b886de2372ee3922fcaf3f78f2d8.js"
+      #
+      # @example Enable Push Promise/Early Hints
+      #
+      #   <%= asset_path "application.js", push: :script %>
       def asset_path(source, push: false, as: nil)
         _asset_url(source, push: push, as: as) { _relative_url(source) }
       end
@@ -700,6 +765,8 @@ module Hanami
       # If CDN mode is on, it returns the absolute URL of the asset.
       #
       # @param source [String] the asset name
+      # @param push [TrueClass, FalseClass, Symbol] HTTP/2 Push Promise/Early Hints flag, or type
+      # @param as [Symbol] HTTP/2 Push Promise / Early Hints flag type
       #
       # @return [String] the asset URL
       #
@@ -732,6 +799,10 @@ module Hanami
       #   <%= asset_url 'application.js' %>
       #
       #   # "https://assets.bookshelf.org/assets/application-28a6b886de2372ee3922fcaf3f78f2d8.js"
+      #
+      # @example Enable Push Promise/Early Hints
+      #
+      #   <%= asset_url "application.js", push: :script %>
       def asset_url(source, push: false, as: nil)
         _asset_url(source, push: push, as: as) { _absolute_url(source) }
       end

--- a/lib/hanami/assets/helpers.rb
+++ b/lib/hanami/assets/helpers.rb
@@ -1,6 +1,4 @@
 require 'uri'
-require 'set'
-require 'thread'
 require 'hanami/helpers/html_helper'
 require 'hanami/utils/escape'
 
@@ -816,10 +814,8 @@ module Hanami
       # @since 0.1.0
       # @api private
       def _push_promise(url)
-        Mutex.new.synchronize do
-          Thread.current[:__hanami_assets] ||= Set.new
-          Thread.current[:__hanami_assets].add(url.to_s)
-        end
+        Thread.current[:__hanami_assets] ||= {}
+        Thread.current[:__hanami_assets][url.to_s] = {}
 
         url
       end

--- a/lib/hanami/assets/helpers.rb
+++ b/lib/hanami/assets/helpers.rb
@@ -167,7 +167,7 @@ module Hanami
       def javascript(*sources, push: true, **options)
         _safe_tags(*sources) do |source|
           tag_options = options.dup
-          tag_options[:src] ||= _typed_asset_path(source, JAVASCRIPT_EXT, push: push, type: :script)
+          tag_options[:src] ||= _typed_asset_path(source, JAVASCRIPT_EXT, push: push, as: :script)
           tag_options[:type] ||= JAVASCRIPT_MIME_TYPE
 
           if _subresource_integrity? || tag_options.include?(:integrity)
@@ -254,7 +254,7 @@ module Hanami
       def stylesheet(*sources, push: true, **options) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
         _safe_tags(*sources) do |source|
           tag_options = options.dup
-          tag_options[:href] ||= _typed_asset_path(source, STYLESHEET_EXT, push: push, type: :style)
+          tag_options[:href] ||= _typed_asset_path(source, STYLESHEET_EXT, push: push, as: :style)
           tag_options[:type] ||= STYLESHEET_MIME_TYPE
           tag_options[:rel] ||= STYLESHEET_REL
 
@@ -333,7 +333,7 @@ module Hanami
       #
       #   # <img src="https://assets.bookshelf.org/assets/logo-28a6b886de2372ee3922fcaf3f78f2d8.png" alt="Logo">
       def image(source, options = {})
-        options[:src] = asset_path(source, push: options.delete(:push) || false, type: :image)
+        options[:src] = asset_path(source, push: options.delete(:push) || false, as: :image)
         options[:alt] ||= Utils::String.titleize(::File.basename(source, WILDCARD_EXT))
 
         html.img(options)
@@ -395,7 +395,7 @@ module Hanami
       #
       #   # <link href="https://assets.bookshelf.org/assets/favicon-28a6b886de2372ee3922fcaf3f78f2d8.ico" rel="shortcut icon" type="image/x-icon">
       def favicon(source = DEFAULT_FAVICON, options = {})
-        options[:href]   = asset_path(source, push: options.delete(:push) || false, type: :image)
+        options[:href]   = asset_path(source, push: options.delete(:push) || false, as: :image)
         options[:rel]  ||= FAVICON_REL
         options[:type] ||= FAVICON_MIME_TYPE
 
@@ -517,7 +517,7 @@ module Hanami
       #
       #   # <video src="https://assets.bookshelf.org/assets/movie-28a6b886de2372ee3922fcaf3f78f2d8.mp4"></video>
       def video(source = nil, options = {}, &blk)
-        options = _source_options(source, options, type: :video, &blk)
+        options = _source_options(source, options, as: :video, &blk)
         html.video(blk, options)
       end
 
@@ -636,7 +636,7 @@ module Hanami
       #
       #   # <audio src="https://assets.bookshelf.org/assets/song-28a6b886de2372ee3922fcaf3f78f2d8.ogg"></audio>
       def audio(source = nil, options = {}, &blk)
-        options = _source_options(source, options, type: :audio, &blk)
+        options = _source_options(source, options, as: :audio, &blk)
         html.audio(blk, options)
       end
 
@@ -684,8 +684,8 @@ module Hanami
       #   <%= asset_path 'application.js' %>
       #
       #   # "https://assets.bookshelf.org/assets/application-28a6b886de2372ee3922fcaf3f78f2d8.js"
-      def asset_path(source, push: false, type: nil)
-        _asset_url(source, push: push, type: type) { _relative_url(source) }
+      def asset_path(source, push: false, as: nil)
+        _asset_url(source, push: push, as: as) { _relative_url(source) }
       end
 
       # It generates the absolute URL for the given source.
@@ -732,8 +732,8 @@ module Hanami
       #   <%= asset_url 'application.js' %>
       #
       #   # "https://assets.bookshelf.org/assets/application-28a6b886de2372ee3922fcaf3f78f2d8.js"
-      def asset_url(source, push: false, type: nil)
-        _asset_url(source, push: push, type: type) { _absolute_url(source) }
+      def asset_url(source, push: false, as: nil)
+        _asset_url(source, push: push, as: as) { _absolute_url(source) }
       end
 
       private
@@ -750,14 +750,14 @@ module Hanami
 
       # @since 0.1.0
       # @api private
-      def _asset_url(source, push:, type:)
+      def _asset_url(source, push:, as:)
         url = _absolute_url?(source) ? source : yield
 
         case push
         when Symbol
-          _push_promise(url, type: push)
+          _push_promise(url, as: push)
         when TrueClass
-          _push_promise(url, type: type)
+          _push_promise(url, as: as)
         end
 
         url
@@ -765,9 +765,9 @@ module Hanami
 
       # @since 0.1.0
       # @api private
-      def _typed_asset_path(source, ext, push: false, type: nil)
+      def _typed_asset_path(source, ext, push: false, as: nil)
         source = "#{source}#{ext}" if _append_extension?(source, ext)
-        asset_path(source, push: push, type: type)
+        asset_path(source, push: push, as: as)
       end
 
       # @api private
@@ -808,13 +808,13 @@ module Hanami
 
       # @since 0.1.0
       # @api private
-      def _source_options(src, options, type:, &_blk)
+      def _source_options(src, options, as:, &_blk)
         options ||= {}
 
         if src.respond_to?(:to_hash)
           options = src.to_hash
         elsif src
-          options[:src] = asset_path(src, push: options.delete(:push) || false, type: type)
+          options[:src] = asset_path(src, push: options.delete(:push) || false, as: as)
         end
 
         if !options[:src] && !block_given?
@@ -826,9 +826,9 @@ module Hanami
 
       # @since 0.1.0
       # @api private
-      def _push_promise(url, type: nil)
+      def _push_promise(url, as: nil)
         Thread.current[:__hanami_assets] ||= {}
-        Thread.current[:__hanami_assets][url.to_s] = { type: type, crossorigin: _crossorigin?(url) }
+        Thread.current[:__hanami_assets][url.to_s] = { as: as, crossorigin: _crossorigin?(url) }
 
         url
       end

--- a/lib/hanami/assets/helpers.rb
+++ b/lib/hanami/assets/helpers.rb
@@ -787,6 +787,13 @@ module Hanami
         ABSOLUTE_URL_MATCHER.match(source)
       end
 
+      # @since x.x.x
+      # @api private
+      def _crossorigin?(source)
+        return false unless _absolute_url?(source)
+        self.class.assets_configuration.crossorigin?(source)
+      end
+
       # @since 0.1.0
       # @api private
       def _relative_url(source)
@@ -821,7 +828,7 @@ module Hanami
       # @api private
       def _push_promise(url, type: nil)
         Thread.current[:__hanami_assets] ||= {}
-        Thread.current[:__hanami_assets][url.to_s] = { type: type }
+        Thread.current[:__hanami_assets][url.to_s] = { type: type, crossorigin: _crossorigin?(url) }
 
         url
       end

--- a/spec/integration/hanami/assets/rendering_spec.rb
+++ b/spec/integration/hanami/assets/rendering_spec.rb
@@ -23,8 +23,8 @@ describe 'Rendering test' do
       result
       assets = Thread.current[:__hanami_assets]
       expect(assets).to be_kind_of(Hash)
-      expect(assets.fetch('/assets/main.css')).to eq(type: :style)
-      expect(assets.fetch('/assets/feature-a.js')).to eq(type: :script)
+      expect(assets.fetch('/assets/main.css')).to eq(type: :style, crossorigin: false)
+      expect(assets.fetch('/assets/feature-a.js')).to eq(type: :script, crossorigin: false)
     end
   end
 
@@ -60,6 +60,10 @@ describe 'Rendering test' do
   end
 
   describe 'with absolute url' do
+    before do
+      Hanami::Assets.configuration.load!
+    end
+
     let(:result) { AbsoluteUrlsView.new.render }
 
     it 'resolves javascript tag' do

--- a/spec/integration/hanami/assets/rendering_spec.rb
+++ b/spec/integration/hanami/assets/rendering_spec.rb
@@ -23,8 +23,8 @@ describe 'Rendering test' do
       result
       assets = Thread.current[:__hanami_assets]
       expect(assets).to be_kind_of(Hash)
-      expect(assets.fetch('/assets/main.css')).to eq(type: :style, crossorigin: false)
-      expect(assets.fetch('/assets/feature-a.js')).to eq(type: :script, crossorigin: false)
+      expect(assets.fetch('/assets/main.css')).to eq(as: :style, crossorigin: false)
+      expect(assets.fetch('/assets/feature-a.js')).to eq(as: :script, crossorigin: false)
     end
   end
 

--- a/spec/integration/hanami/assets/rendering_spec.rb
+++ b/spec/integration/hanami/assets/rendering_spec.rb
@@ -23,8 +23,8 @@ describe 'Rendering test' do
       result
       assets = Thread.current[:__hanami_assets]
       expect(assets).to be_kind_of(Hash)
-      expect(assets.fetch('/assets/main.css')).to eq({})
-      expect(assets.fetch('/assets/feature-a.js')).to eq({})
+      expect(assets.fetch('/assets/main.css')).to eq(type: :style)
+      expect(assets.fetch('/assets/feature-a.js')).to eq(type: :script)
     end
   end
 

--- a/spec/integration/hanami/assets/rendering_spec.rb
+++ b/spec/integration/hanami/assets/rendering_spec.rb
@@ -22,8 +22,9 @@ describe 'Rendering test' do
     it 'stores assets in thread local' do
       result
       assets = Thread.current[:__hanami_assets]
-      expect(assets).to include '/assets/main.css'
-      expect(assets).to include '/assets/feature-a.js'
+      expect(assets).to be_kind_of(Hash)
+      expect(assets.fetch('/assets/main.css')).to eq({})
+      expect(assets.fetch('/assets/feature-a.js')).to eq({})
     end
   end
 

--- a/spec/unit/hanami/assets/configuration_spec.rb
+++ b/spec/unit/hanami/assets/configuration_spec.rb
@@ -465,6 +465,68 @@ describe Hanami::Assets::Configuration do
     end
   end
 
+  describe "#crossorigin?" do
+    after do
+      @configuration.reset!
+    end
+
+    context "development mode" do
+      before do
+        @configuration.load!
+      end
+
+      it "returns false when scheme, host, and port match" do
+        expect(@configuration.crossorigin?("http://localhost:2300/assets/application.js")).to be(false)
+      end
+
+      it "returns true when scheme doesn't match" do
+        expect(@configuration.crossorigin?("https://localhost:2300/assets/application.js")).to be(true)
+      end
+
+      it "returns true when host doesn't match" do
+        expect(@configuration.crossorigin?("http://some-host:2300/assets/application.js")).to be(true)
+      end
+
+      it "returns true when uses a subdomain" do
+        expect(@configuration.crossorigin?("http://assets.localhost:2300/assets/application.js")).to be(true)
+      end
+
+      it "returns true when port doesn't match" do
+        expect(@configuration.crossorigin?("http://localhost:8080/assets/application.js")).to be(true)
+      end
+    end
+
+    describe "production mode" do
+      before do
+        @configuration.scheme "https"
+        @configuration.host   "hanamirb.org"
+        @configuration.port   443
+        @configuration.load!
+      end
+
+      it "returns false when scheme, host, and port match" do
+        expect(@configuration.crossorigin?("https://hanamirb.org/assets/application.js")).to be(false)
+      end
+
+      it "returns true when scheme doesn't match" do
+        expect(@configuration.crossorigin?("http://hanamirb.org/assets/application.js")).to be(true)
+      end
+
+      it "returns true when host doesn't match" do
+        expect(@configuration.crossorigin?("https://hanamirb.test/assets/application.js")).to be(true)
+      end
+
+      it "returns true when uses a subdomain" do
+        expect(@configuration.crossorigin?("https://www.hanamirb.org/assets/application.js")).to be(true)
+      end
+
+      xit "returns true when port doesn't match" do
+        @configuration.crossorigin?("https://hanamirb.org:8081/assets/application.js")
+        expect(@configuration.crossorigin?("https://hanamirb.org:8081/assets/application.js")).to be(true)
+      end
+    end
+  end
+
   describe 'subresource_integrity_value' do
     describe 'subresource_integrity mode' do
       before do

--- a/spec/unit/hanami/assets/helpers_spec.rb
+++ b/spec/unit/hanami/assets/helpers_spec.rb
@@ -2,6 +2,10 @@ describe Hanami::Assets::Helpers do
   let(:view)    { ImageHelperView.new({}, {}) }
   let(:cdn_url) { 'https://bookshelf.cdn-example.com' }
 
+  before do
+    Thread.current[:__hanami_assets] = nil
+  end
+
   after do
     view.class.assets_configuration.reset!
   end
@@ -70,6 +74,38 @@ describe Hanami::Assets::Helpers do
         expect(actual).to eq(%(<script src="#{cdn_url}/assets/feature-a.js" type="text/javascript"></script>))
       end
     end
+
+    context "HTTP/2 PUSH PROMISE" do
+      it "includes asset in push promise assets" do
+        DefaultView.new.javascript("feature-a")
+        assets = Thread.current[:__hanami_assets]
+
+        expect(assets.fetch("/assets/feature-a.js")).to eq({})
+      end
+
+      it "allows asset exclusion from push promise assets" do
+        actual = DefaultView.new.javascript("feature-b", push: false)
+        expect(actual).to eq(%(<script src="/assets/feature-b.js" type="text/javascript"></script>))
+        assets = Thread.current[:__hanami_assets]
+
+        expect(assets).to be(nil)
+      end
+
+      it "includes multiple assets in push promise assets" do
+        DefaultView.new.javascript("feature-c", "feature-d")
+        assets = Thread.current[:__hanami_assets]
+
+        expect(assets.fetch("/assets/feature-c.js")).to eq({})
+        expect(assets.fetch("/assets/feature-d.js")).to eq({})
+      end
+
+      it "allows the exclusion of multiple assets from push promise assets" do
+        DefaultView.new.javascript("feature-e", "feature-f", push: false)
+        assets = Thread.current[:__hanami_assets]
+
+        expect(assets).to be(nil)
+      end
+    end
   end
 
   describe '#stylesheet' do
@@ -119,6 +155,38 @@ describe Hanami::Assets::Helpers do
         expect(actual).to eq(%(<link href="#{cdn_url}/assets/main.css" type="text/css" rel="stylesheet">))
       end
     end
+
+    context "HTTP/2 PUSH PROMISE" do
+      it "includes asset in push promise assets" do
+        DefaultView.new.stylesheet("main")
+        assets = Thread.current[:__hanami_assets]
+
+        expect(assets.fetch("/assets/main.css")).to eq({})
+      end
+
+      it "allows asset exclusion from push promise assets" do
+        actual = DefaultView.new.stylesheet("fonts", push: false)
+        expect(actual).to eq(%(<link href="/assets/fonts.css" type="text/css" rel="stylesheet">))
+        assets = Thread.current[:__hanami_assets]
+
+        expect(assets).to be(nil)
+      end
+
+      it "includes multiple assets in push promise assets" do
+        DefaultView.new.stylesheet("framework", "styles")
+        assets = Thread.current[:__hanami_assets]
+
+        expect(assets.fetch("/assets/framework.css")).to eq({})
+        expect(assets.fetch("/assets/styles.css")).to eq({})
+      end
+
+      it "allows the exclusion of multiple assets from push promise assets" do
+        DefaultView.new.stylesheet("framework", "styles", push: false)
+        assets = Thread.current[:__hanami_assets]
+
+        expect(assets).to be(nil)
+      end
+    end
   end
 
   describe 'image' do
@@ -152,6 +220,23 @@ describe Hanami::Assets::Helpers do
         expect(actual).to eq(%(<img src="#{cdn_url}/assets/application.jpg" alt="Application">))
       end
     end
+
+    context "HTTP/2 PUSH PROMISE" do
+      it "doesn't include asset in push promise assets" do
+        view.image("application.jpg")
+        assets = Thread.current[:__hanami_assets]
+
+        expect(assets).to be(nil)
+      end
+
+      it "allows assets inclusion in push promise assets" do
+        actual = view.image("application.jpg", push: true).to_s
+        expect(actual).to eq(%(<img src="/assets/application.jpg" alt="Application">))
+
+        assets = Thread.current[:__hanami_assets]
+        expect(assets.fetch("/assets/application.jpg")).to eq({})
+      end
+    end
   end
 
   describe '#favicon' do
@@ -178,6 +263,23 @@ describe Hanami::Assets::Helpers do
       it 'returns absolute url for href attribute' do
         actual = view.favicon.to_s
         expect(actual).to eq(%(<link href="#{cdn_url}/assets/favicon.ico" rel="shortcut icon" type="image/x-icon">))
+      end
+    end
+
+    context "HTTP/2 PUSH PROMISE" do
+      it "doesn't include asset in push promise assets" do
+        view.favicon
+        assets = Thread.current[:__hanami_assets]
+
+        expect(assets).to be(nil)
+      end
+
+      it "allows assets inclusion in push promise assets" do
+        actual = view.favicon("favicon.ico", push: true).to_s
+        expect(actual).to eq(%(<link href="/assets/favicon.ico" rel="shortcut icon" type="image/x-icon">))
+
+        assets = Thread.current[:__hanami_assets]
+        expect(assets.fetch("/assets/favicon.ico")).to eq({})
       end
     end
   end
@@ -248,6 +350,47 @@ describe Hanami::Assets::Helpers do
         expect(actual).to eq(%(<video src="#{cdn_url}/assets/movie.mp4"></video>))
       end
     end
+
+    context "HTTP/2 PUSH PROMISE" do
+      it "doesn't include asset in push promise assets" do
+        view.video("movie.mp4")
+        assets = Thread.current[:__hanami_assets]
+
+        expect(assets).to be(nil)
+      end
+
+      it "allows asset inclusion in push promise assets" do
+        actual = view.video("movie.mp4", push: true).to_s
+        expect(actual).to eq(%(<video src="/assets/movie.mp4"></video>))
+
+        assets = Thread.current[:__hanami_assets]
+        expect(assets.fetch("/assets/movie.mp4")).to eq({})
+      end
+
+      it "allows asset inclusion in push promise assets when using block syntax" do
+        actual = view.video("movie.mp4", push: true) do
+          "Your browser does not support the video tag"
+        end.to_s
+
+        expect(actual).to eq(%(<video src="/assets/movie.mp4">\nYour browser does not support the video tag\n</video>))
+
+        assets = Thread.current[:__hanami_assets]
+        expect(assets.fetch("/assets/movie.mp4")).to eq({})
+      end
+
+      it "allows asset inclusion in push promise assets when using block syntax and source tags" do
+        actual = view.video do
+          text "Your browser does not support the video tag"
+          source src: view.asset_path("movie.mp4", push: true), type: "video/mp4"
+          source src: view.asset_path("movie.ogg"), type: "video/ogg"
+        end.to_s
+
+        expect(actual).to eq(%(<video>\nYour browser does not support the video tag\n<source src="/assets/movie.mp4" type="video/mp4">\n<source src="/assets/movie.ogg" type="video/ogg">\n</video>))
+
+        assets = Thread.current[:__hanami_assets]
+        expect(assets.fetch("/assets/movie.mp4")).to eq({})
+      end
+    end
   end
 
   describe '#audio' do
@@ -316,6 +459,47 @@ describe Hanami::Assets::Helpers do
         expect(actual).to eq(%(<audio src="#{cdn_url}/assets/song.ogg"></audio>))
       end
     end
+
+    context "HTTP/2 PUSH PROMISE" do
+      it "doesn't include asset in push promise assets" do
+        view.audio("song.ogg")
+        assets = Thread.current[:__hanami_assets]
+
+        expect(assets).to be(nil)
+      end
+
+      it "allows asset inclusion in push promise assets" do
+        actual = view.audio("song.ogg", push: true).to_s
+        expect(actual).to eq(%(<audio src="/assets/song.ogg"></audio>))
+
+        assets = Thread.current[:__hanami_assets]
+        expect(assets.fetch("/assets/song.ogg")).to eq({})
+      end
+
+      it "allows asset inclusion in push promise assets when using block syntax" do
+        actual = view.audio("song.ogg", push: true) do
+          "Your browser does not support the audio tag"
+        end.to_s
+
+        expect(actual).to eq(%(<audio src="/assets/song.ogg">\nYour browser does not support the audio tag\n</audio>))
+
+        assets = Thread.current[:__hanami_assets]
+        expect(assets.fetch("/assets/song.ogg")).to eq({})
+      end
+
+      it "allows asset inclusion in push promise assets when using block syntax and source tags" do
+        actual = view.audio do
+          text "Your browser does not support the audio tag"
+          source src: view.asset_path("song.ogg", push: true), type: "audio/ogg"
+          source src: view.asset_path("song.wav"), type: "audio/wav"
+        end.to_s
+
+        expect(actual).to eq(%(<audio>\nYour browser does not support the audio tag\n<source src="/assets/song.ogg" type="audio/ogg">\n<source src="/assets/song.wav" type="audio/wav">\n</audio>))
+
+        assets = Thread.current[:__hanami_assets]
+        expect(assets.fetch("/assets/song.ogg")).to eq({})
+      end
+    end
   end
 
   describe '#asset_path' do
@@ -329,12 +513,6 @@ describe Hanami::Assets::Helpers do
       expect(result).to eq('http://assets.hanamirb.org/assets/application.css')
     end
 
-    it 'adds source to HTTP/2 PUSH PROMISE list' do
-      view.asset_path('dashboard.js')
-      expect(Thread.current[:__hanami_assets]).to be_kind_of(Hash)
-      expect(Thread.current[:__hanami_assets].fetch('/assets/dashboard.js')).to eq({})
-    end
-
     describe 'cdn mode' do
       before do
         activate_cdn_mode!
@@ -343,6 +521,23 @@ describe Hanami::Assets::Helpers do
       it 'returns absolute url' do
         result = view.asset_path('application.js')
         expect(result).to eq('https://bookshelf.cdn-example.com/assets/application.js')
+      end
+    end
+
+    context "HTTP/2 PUSH PROMISE" do
+      it "doesn't add into assets list by default" do
+        view.asset_path("dashboard.js")
+        assets = Thread.current[:__hanami_assets]
+
+        expect(assets).to be(nil)
+      end
+
+      it "adds asset into assets list" do
+        view.asset_path("dashboard.js", push: true)
+        assets = Thread.current[:__hanami_assets]
+
+        expect(assets).to be_kind_of(Hash)
+        expect(assets.fetch('/assets/dashboard.js')).to eq({})
       end
     end
   end
@@ -362,11 +557,6 @@ describe Hanami::Assets::Helpers do
       expect(result).to eq('http://assets.hanamirb.org/assets/application.css')
     end
 
-    it 'adds source to HTTP/2 PUSH PROMISE list' do
-      view.asset_url('metrics.js')
-      expect(Thread.current[:__hanami_assets]).to include('http://localhost:2300/assets/metrics.js')
-    end
-
     describe 'cdn mode' do
       before do
         activate_cdn_mode!
@@ -375,6 +565,23 @@ describe Hanami::Assets::Helpers do
       it 'still returns absolute url' do
         result = view.asset_url('application.js')
         expect(result).to eq('https://bookshelf.cdn-example.com/assets/application.js')
+      end
+    end
+
+    context "HTTP/2 PUSH PROMISE" do
+      it "doesn't add into assets list by default" do
+        view.asset_url("metrics.js")
+        assets = Thread.current[:__hanami_assets]
+
+        expect(assets).to be(nil)
+      end
+
+      it "adds asset into assets list" do
+        view.asset_url("metrics.js", push: true)
+        assets = Thread.current[:__hanami_assets]
+
+        expect(assets).to be_kind_of(Hash)
+        expect(assets.fetch("http://localhost:2300/assets/metrics.js")).to eq({})
       end
     end
   end

--- a/spec/unit/hanami/assets/helpers_spec.rb
+++ b/spec/unit/hanami/assets/helpers_spec.rb
@@ -3,6 +3,7 @@ describe Hanami::Assets::Helpers do
   let(:cdn_url) { 'https://bookshelf.cdn-example.com' }
 
   before do
+    view.class.assets_configuration.load!
     Thread.current[:__hanami_assets] = nil
   end
 
@@ -80,7 +81,14 @@ describe Hanami::Assets::Helpers do
         DefaultView.new.javascript("feature-a")
         assets = Thread.current[:__hanami_assets]
 
-        expect(assets.fetch("/assets/feature-a.js")).to eq(type: :script)
+        expect(assets.fetch("/assets/feature-a.js")).to eq(type: :script, crossorigin: false)
+      end
+
+      it "includes crossorigin asset in push promise assets" do
+        DefaultView.new.javascript("https://assets.hanamirb.org/assets/framework.js")
+        assets = Thread.current[:__hanami_assets]
+
+        expect(assets.fetch("https://assets.hanamirb.org/assets/framework.js")).to eq(type: :script, crossorigin: true)
       end
 
       it "allows asset exclusion from push promise assets" do
@@ -95,8 +103,8 @@ describe Hanami::Assets::Helpers do
         DefaultView.new.javascript("feature-c", "feature-d")
         assets = Thread.current[:__hanami_assets]
 
-        expect(assets.fetch("/assets/feature-c.js")).to eq(type: :script)
-        expect(assets.fetch("/assets/feature-d.js")).to eq(type: :script)
+        expect(assets.fetch("/assets/feature-c.js")).to eq(type: :script, crossorigin: false)
+        expect(assets.fetch("/assets/feature-d.js")).to eq(type: :script, crossorigin: false)
       end
 
       it "allows the exclusion of multiple assets from push promise assets" do
@@ -161,7 +169,7 @@ describe Hanami::Assets::Helpers do
         DefaultView.new.stylesheet("main")
         assets = Thread.current[:__hanami_assets]
 
-        expect(assets.fetch("/assets/main.css")).to eq(type: :style)
+        expect(assets.fetch("/assets/main.css")).to eq(type: :style, crossorigin: false)
       end
 
       it "allows asset exclusion from push promise assets" do
@@ -176,8 +184,8 @@ describe Hanami::Assets::Helpers do
         DefaultView.new.stylesheet("framework", "styles")
         assets = Thread.current[:__hanami_assets]
 
-        expect(assets.fetch("/assets/framework.css")).to eq(type: :style)
-        expect(assets.fetch("/assets/styles.css")).to eq(type: :style)
+        expect(assets.fetch("/assets/framework.css")).to eq(type: :style, crossorigin: false)
+        expect(assets.fetch("/assets/styles.css")).to eq(type: :style, crossorigin: false)
       end
 
       it "allows the exclusion of multiple assets from push promise assets" do
@@ -234,7 +242,15 @@ describe Hanami::Assets::Helpers do
         expect(actual).to eq(%(<img src="/assets/application.jpg" alt="Application">))
 
         assets = Thread.current[:__hanami_assets]
-        expect(assets.fetch("/assets/application.jpg")).to eq(type: :image)
+        expect(assets.fetch("/assets/application.jpg")).to eq(type: :image, crossorigin: false)
+      end
+
+      it "allows crossorigin assets inclusion in push promise assets" do
+        actual = view.image("https://assets.hanamirb.org/assets/application.jpg", push: true).to_s
+        expect(actual).to eq(%(<img src="https://assets.hanamirb.org/assets/application.jpg" alt="Application">))
+
+        assets = Thread.current[:__hanami_assets]
+        expect(assets.fetch("https://assets.hanamirb.org/assets/application.jpg")).to eq(type: :image, crossorigin: true)
       end
     end
   end
@@ -279,7 +295,15 @@ describe Hanami::Assets::Helpers do
         expect(actual).to eq(%(<link href="/assets/favicon.ico" rel="shortcut icon" type="image/x-icon">))
 
         assets = Thread.current[:__hanami_assets]
-        expect(assets.fetch("/assets/favicon.ico")).to eq(type: :image)
+        expect(assets.fetch("/assets/favicon.ico")).to eq(type: :image, crossorigin: false)
+      end
+
+      it "allows crossorigin assets inclusion in push promise assets" do
+        actual = view.favicon("https://assets.hanamirb.org/assets/favicon.ico", push: true).to_s
+        expect(actual).to eq(%(<link href="https://assets.hanamirb.org/assets/favicon.ico" rel="shortcut icon" type="image/x-icon">))
+
+        assets = Thread.current[:__hanami_assets]
+        expect(assets.fetch("https://assets.hanamirb.org/assets/favicon.ico")).to eq(type: :image, crossorigin: true)
       end
     end
   end
@@ -364,7 +388,15 @@ describe Hanami::Assets::Helpers do
         expect(actual).to eq(%(<video src="/assets/movie.mp4"></video>))
 
         assets = Thread.current[:__hanami_assets]
-        expect(assets.fetch("/assets/movie.mp4")).to eq(type: :video)
+        expect(assets.fetch("/assets/movie.mp4")).to eq(type: :video, crossorigin: false)
+      end
+
+      it "allows crossorigin asset inclusion in push promise assets" do
+        actual = view.video("https://assets.hanamirb.org/assets/movie.mp4", push: true).to_s
+        expect(actual).to eq(%(<video src="https://assets.hanamirb.org/assets/movie.mp4"></video>))
+
+        assets = Thread.current[:__hanami_assets]
+        expect(assets.fetch("https://assets.hanamirb.org/assets/movie.mp4")).to eq(type: :video, crossorigin: true)
       end
 
       it "allows asset inclusion in push promise assets when using block syntax" do
@@ -375,7 +407,7 @@ describe Hanami::Assets::Helpers do
         expect(actual).to eq(%(<video src="/assets/movie.mp4">\nYour browser does not support the video tag\n</video>))
 
         assets = Thread.current[:__hanami_assets]
-        expect(assets.fetch("/assets/movie.mp4")).to eq(type: :video)
+        expect(assets.fetch("/assets/movie.mp4")).to eq(type: :video, crossorigin: false)
       end
 
       it "allows asset inclusion in push promise assets when using block syntax and source tags" do
@@ -388,7 +420,7 @@ describe Hanami::Assets::Helpers do
         expect(actual).to eq(%(<video>\nYour browser does not support the video tag\n<source src="/assets/movie.mp4" type="video/mp4">\n<source src="/assets/movie.ogg" type="video/ogg">\n</video>))
 
         assets = Thread.current[:__hanami_assets]
-        expect(assets.fetch("/assets/movie.mp4")).to eq(type: :video)
+        expect(assets.fetch("/assets/movie.mp4")).to eq(type: :video, crossorigin: false)
       end
     end
   end
@@ -473,7 +505,15 @@ describe Hanami::Assets::Helpers do
         expect(actual).to eq(%(<audio src="/assets/song.ogg"></audio>))
 
         assets = Thread.current[:__hanami_assets]
-        expect(assets.fetch("/assets/song.ogg")).to eq(type: :audio)
+        expect(assets.fetch("/assets/song.ogg")).to eq(type: :audio, crossorigin: false)
+      end
+
+      it "allows crossorigin asset inclusion in push promise assets" do
+        actual = view.audio("https://assets.hanamirbg.org/assets/song.ogg", push: true).to_s
+        expect(actual).to eq(%(<audio src="https://assets.hanamirbg.org/assets/song.ogg"></audio>))
+
+        assets = Thread.current[:__hanami_assets]
+        expect(assets.fetch("https://assets.hanamirbg.org/assets/song.ogg")).to eq(type: :audio, crossorigin: true)
       end
 
       it "allows asset inclusion in push promise assets when using block syntax" do
@@ -484,7 +524,7 @@ describe Hanami::Assets::Helpers do
         expect(actual).to eq(%(<audio src="/assets/song.ogg">\nYour browser does not support the audio tag\n</audio>))
 
         assets = Thread.current[:__hanami_assets]
-        expect(assets.fetch("/assets/song.ogg")).to eq(type: :audio)
+        expect(assets.fetch("/assets/song.ogg")).to eq(type: :audio, crossorigin: false)
       end
 
       it "allows asset inclusion in push promise assets when using block syntax and source tags" do
@@ -497,7 +537,7 @@ describe Hanami::Assets::Helpers do
         expect(actual).to eq(%(<audio>\nYour browser does not support the audio tag\n<source src="/assets/song.ogg" type="audio/ogg">\n<source src="/assets/song.wav" type="audio/wav">\n</audio>))
 
         assets = Thread.current[:__hanami_assets]
-        expect(assets.fetch("/assets/song.ogg")).to eq(type: :audio)
+        expect(assets.fetch("/assets/song.ogg")).to eq(type: :audio, crossorigin: false)
       end
     end
   end
@@ -537,7 +577,7 @@ describe Hanami::Assets::Helpers do
         assets = Thread.current[:__hanami_assets]
 
         expect(assets).to be_kind_of(Hash)
-        expect(assets.fetch('/assets/dashboard.js')).to eq(type: nil)
+        expect(assets.fetch('/assets/dashboard.js')).to eq(type: nil, crossorigin: false)
       end
 
       it "allows to specify asset type" do
@@ -545,7 +585,15 @@ describe Hanami::Assets::Helpers do
         assets = Thread.current[:__hanami_assets]
 
         expect(assets).to be_kind_of(Hash)
-        expect(assets.fetch('/assets/video.mp4')).to eq(type: :video)
+        expect(assets.fetch('/assets/video.mp4')).to eq(type: :video, crossorigin: false)
+      end
+
+      it "allows to link crossorigin asset" do
+        view.asset_path("https://assets.hanamirb.org/assets/video.mp4", push: :video)
+        assets = Thread.current[:__hanami_assets]
+
+        expect(assets).to be_kind_of(Hash)
+        expect(assets.fetch("https://assets.hanamirb.org/assets/video.mp4")).to eq(type: :video, crossorigin: true)
       end
     end
   end
@@ -589,7 +637,7 @@ describe Hanami::Assets::Helpers do
         assets = Thread.current[:__hanami_assets]
 
         expect(assets).to be_kind_of(Hash)
-        expect(assets.fetch("http://localhost:2300/assets/metrics.js")).to eq(type: nil)
+        expect(assets.fetch("http://localhost:2300/assets/metrics.js")).to eq(type: nil, crossorigin: false)
       end
 
       it "allows to specify asset type" do
@@ -597,7 +645,15 @@ describe Hanami::Assets::Helpers do
         assets = Thread.current[:__hanami_assets]
 
         expect(assets).to be_kind_of(Hash)
-        expect(assets.fetch("http://localhost:2300/assets/metrics.js")).to eq(type: :script)
+        expect(assets.fetch("http://localhost:2300/assets/metrics.js")).to eq(type: :script, crossorigin: false)
+      end
+
+      it "allows to link crossorigin asset" do
+        view.asset_url("https://assets.hanamirb.org/assets/metrics.js", push: :script)
+        assets = Thread.current[:__hanami_assets]
+
+        expect(assets).to be_kind_of(Hash)
+        expect(assets.fetch("https://assets.hanamirb.org/assets/metrics.js")).to eq(type: :script, crossorigin: true)
       end
     end
   end

--- a/spec/unit/hanami/assets/helpers_spec.rb
+++ b/spec/unit/hanami/assets/helpers_spec.rb
@@ -80,7 +80,7 @@ describe Hanami::Assets::Helpers do
         DefaultView.new.javascript("feature-a")
         assets = Thread.current[:__hanami_assets]
 
-        expect(assets.fetch("/assets/feature-a.js")).to eq({})
+        expect(assets.fetch("/assets/feature-a.js")).to eq(type: :script)
       end
 
       it "allows asset exclusion from push promise assets" do
@@ -95,8 +95,8 @@ describe Hanami::Assets::Helpers do
         DefaultView.new.javascript("feature-c", "feature-d")
         assets = Thread.current[:__hanami_assets]
 
-        expect(assets.fetch("/assets/feature-c.js")).to eq({})
-        expect(assets.fetch("/assets/feature-d.js")).to eq({})
+        expect(assets.fetch("/assets/feature-c.js")).to eq(type: :script)
+        expect(assets.fetch("/assets/feature-d.js")).to eq(type: :script)
       end
 
       it "allows the exclusion of multiple assets from push promise assets" do
@@ -161,7 +161,7 @@ describe Hanami::Assets::Helpers do
         DefaultView.new.stylesheet("main")
         assets = Thread.current[:__hanami_assets]
 
-        expect(assets.fetch("/assets/main.css")).to eq({})
+        expect(assets.fetch("/assets/main.css")).to eq(type: :style)
       end
 
       it "allows asset exclusion from push promise assets" do
@@ -176,8 +176,8 @@ describe Hanami::Assets::Helpers do
         DefaultView.new.stylesheet("framework", "styles")
         assets = Thread.current[:__hanami_assets]
 
-        expect(assets.fetch("/assets/framework.css")).to eq({})
-        expect(assets.fetch("/assets/styles.css")).to eq({})
+        expect(assets.fetch("/assets/framework.css")).to eq(type: :style)
+        expect(assets.fetch("/assets/styles.css")).to eq(type: :style)
       end
 
       it "allows the exclusion of multiple assets from push promise assets" do
@@ -234,7 +234,7 @@ describe Hanami::Assets::Helpers do
         expect(actual).to eq(%(<img src="/assets/application.jpg" alt="Application">))
 
         assets = Thread.current[:__hanami_assets]
-        expect(assets.fetch("/assets/application.jpg")).to eq({})
+        expect(assets.fetch("/assets/application.jpg")).to eq(type: :image)
       end
     end
   end
@@ -279,7 +279,7 @@ describe Hanami::Assets::Helpers do
         expect(actual).to eq(%(<link href="/assets/favicon.ico" rel="shortcut icon" type="image/x-icon">))
 
         assets = Thread.current[:__hanami_assets]
-        expect(assets.fetch("/assets/favicon.ico")).to eq({})
+        expect(assets.fetch("/assets/favicon.ico")).to eq(type: :image)
       end
     end
   end
@@ -364,7 +364,7 @@ describe Hanami::Assets::Helpers do
         expect(actual).to eq(%(<video src="/assets/movie.mp4"></video>))
 
         assets = Thread.current[:__hanami_assets]
-        expect(assets.fetch("/assets/movie.mp4")).to eq({})
+        expect(assets.fetch("/assets/movie.mp4")).to eq(type: :video)
       end
 
       it "allows asset inclusion in push promise assets when using block syntax" do
@@ -375,20 +375,20 @@ describe Hanami::Assets::Helpers do
         expect(actual).to eq(%(<video src="/assets/movie.mp4">\nYour browser does not support the video tag\n</video>))
 
         assets = Thread.current[:__hanami_assets]
-        expect(assets.fetch("/assets/movie.mp4")).to eq({})
+        expect(assets.fetch("/assets/movie.mp4")).to eq(type: :video)
       end
 
       it "allows asset inclusion in push promise assets when using block syntax and source tags" do
         actual = view.video do
           text "Your browser does not support the video tag"
-          source src: view.asset_path("movie.mp4", push: true), type: "video/mp4"
+          source src: view.asset_path("movie.mp4", push: :video), type: "video/mp4"
           source src: view.asset_path("movie.ogg"), type: "video/ogg"
         end.to_s
 
         expect(actual).to eq(%(<video>\nYour browser does not support the video tag\n<source src="/assets/movie.mp4" type="video/mp4">\n<source src="/assets/movie.ogg" type="video/ogg">\n</video>))
 
         assets = Thread.current[:__hanami_assets]
-        expect(assets.fetch("/assets/movie.mp4")).to eq({})
+        expect(assets.fetch("/assets/movie.mp4")).to eq(type: :video)
       end
     end
   end
@@ -473,7 +473,7 @@ describe Hanami::Assets::Helpers do
         expect(actual).to eq(%(<audio src="/assets/song.ogg"></audio>))
 
         assets = Thread.current[:__hanami_assets]
-        expect(assets.fetch("/assets/song.ogg")).to eq({})
+        expect(assets.fetch("/assets/song.ogg")).to eq(type: :audio)
       end
 
       it "allows asset inclusion in push promise assets when using block syntax" do
@@ -484,20 +484,20 @@ describe Hanami::Assets::Helpers do
         expect(actual).to eq(%(<audio src="/assets/song.ogg">\nYour browser does not support the audio tag\n</audio>))
 
         assets = Thread.current[:__hanami_assets]
-        expect(assets.fetch("/assets/song.ogg")).to eq({})
+        expect(assets.fetch("/assets/song.ogg")).to eq(type: :audio)
       end
 
       it "allows asset inclusion in push promise assets when using block syntax and source tags" do
         actual = view.audio do
           text "Your browser does not support the audio tag"
-          source src: view.asset_path("song.ogg", push: true), type: "audio/ogg"
+          source src: view.asset_path("song.ogg", push: :audio), type: "audio/ogg"
           source src: view.asset_path("song.wav"), type: "audio/wav"
         end.to_s
 
         expect(actual).to eq(%(<audio>\nYour browser does not support the audio tag\n<source src="/assets/song.ogg" type="audio/ogg">\n<source src="/assets/song.wav" type="audio/wav">\n</audio>))
 
         assets = Thread.current[:__hanami_assets]
-        expect(assets.fetch("/assets/song.ogg")).to eq({})
+        expect(assets.fetch("/assets/song.ogg")).to eq(type: :audio)
       end
     end
   end
@@ -537,7 +537,15 @@ describe Hanami::Assets::Helpers do
         assets = Thread.current[:__hanami_assets]
 
         expect(assets).to be_kind_of(Hash)
-        expect(assets.fetch('/assets/dashboard.js')).to eq({})
+        expect(assets.fetch('/assets/dashboard.js')).to eq(type: nil)
+      end
+
+      it "allows to specify asset type" do
+        view.asset_path("video.mp4", push: :video)
+        assets = Thread.current[:__hanami_assets]
+
+        expect(assets).to be_kind_of(Hash)
+        expect(assets.fetch('/assets/video.mp4')).to eq(type: :video)
       end
     end
   end
@@ -581,7 +589,15 @@ describe Hanami::Assets::Helpers do
         assets = Thread.current[:__hanami_assets]
 
         expect(assets).to be_kind_of(Hash)
-        expect(assets.fetch("http://localhost:2300/assets/metrics.js")).to eq({})
+        expect(assets.fetch("http://localhost:2300/assets/metrics.js")).to eq(type: nil)
+      end
+
+      it "allows to specify asset type" do
+        view.asset_url("metrics.js", push: :script)
+        assets = Thread.current[:__hanami_assets]
+
+        expect(assets).to be_kind_of(Hash)
+        expect(assets.fetch("http://localhost:2300/assets/metrics.js")).to eq(type: :script)
       end
     end
   end

--- a/spec/unit/hanami/assets/helpers_spec.rb
+++ b/spec/unit/hanami/assets/helpers_spec.rb
@@ -81,14 +81,14 @@ describe Hanami::Assets::Helpers do
         DefaultView.new.javascript("feature-a")
         assets = Thread.current[:__hanami_assets]
 
-        expect(assets.fetch("/assets/feature-a.js")).to eq(type: :script, crossorigin: false)
+        expect(assets.fetch("/assets/feature-a.js")).to eq(as: :script, crossorigin: false)
       end
 
       it "includes crossorigin asset in push promise assets" do
         DefaultView.new.javascript("https://assets.hanamirb.org/assets/framework.js")
         assets = Thread.current[:__hanami_assets]
 
-        expect(assets.fetch("https://assets.hanamirb.org/assets/framework.js")).to eq(type: :script, crossorigin: true)
+        expect(assets.fetch("https://assets.hanamirb.org/assets/framework.js")).to eq(as: :script, crossorigin: true)
       end
 
       it "allows asset exclusion from push promise assets" do
@@ -103,8 +103,8 @@ describe Hanami::Assets::Helpers do
         DefaultView.new.javascript("feature-c", "feature-d")
         assets = Thread.current[:__hanami_assets]
 
-        expect(assets.fetch("/assets/feature-c.js")).to eq(type: :script, crossorigin: false)
-        expect(assets.fetch("/assets/feature-d.js")).to eq(type: :script, crossorigin: false)
+        expect(assets.fetch("/assets/feature-c.js")).to eq(as: :script, crossorigin: false)
+        expect(assets.fetch("/assets/feature-d.js")).to eq(as: :script, crossorigin: false)
       end
 
       it "allows the exclusion of multiple assets from push promise assets" do
@@ -169,7 +169,7 @@ describe Hanami::Assets::Helpers do
         DefaultView.new.stylesheet("main")
         assets = Thread.current[:__hanami_assets]
 
-        expect(assets.fetch("/assets/main.css")).to eq(type: :style, crossorigin: false)
+        expect(assets.fetch("/assets/main.css")).to eq(as: :style, crossorigin: false)
       end
 
       it "allows asset exclusion from push promise assets" do
@@ -184,8 +184,8 @@ describe Hanami::Assets::Helpers do
         DefaultView.new.stylesheet("framework", "styles")
         assets = Thread.current[:__hanami_assets]
 
-        expect(assets.fetch("/assets/framework.css")).to eq(type: :style, crossorigin: false)
-        expect(assets.fetch("/assets/styles.css")).to eq(type: :style, crossorigin: false)
+        expect(assets.fetch("/assets/framework.css")).to eq(as: :style, crossorigin: false)
+        expect(assets.fetch("/assets/styles.css")).to eq(as: :style, crossorigin: false)
       end
 
       it "allows the exclusion of multiple assets from push promise assets" do
@@ -242,7 +242,7 @@ describe Hanami::Assets::Helpers do
         expect(actual).to eq(%(<img src="/assets/application.jpg" alt="Application">))
 
         assets = Thread.current[:__hanami_assets]
-        expect(assets.fetch("/assets/application.jpg")).to eq(type: :image, crossorigin: false)
+        expect(assets.fetch("/assets/application.jpg")).to eq(as: :image, crossorigin: false)
       end
 
       it "allows crossorigin assets inclusion in push promise assets" do
@@ -250,7 +250,7 @@ describe Hanami::Assets::Helpers do
         expect(actual).to eq(%(<img src="https://assets.hanamirb.org/assets/application.jpg" alt="Application">))
 
         assets = Thread.current[:__hanami_assets]
-        expect(assets.fetch("https://assets.hanamirb.org/assets/application.jpg")).to eq(type: :image, crossorigin: true)
+        expect(assets.fetch("https://assets.hanamirb.org/assets/application.jpg")).to eq(as: :image, crossorigin: true)
       end
     end
   end
@@ -295,7 +295,7 @@ describe Hanami::Assets::Helpers do
         expect(actual).to eq(%(<link href="/assets/favicon.ico" rel="shortcut icon" type="image/x-icon">))
 
         assets = Thread.current[:__hanami_assets]
-        expect(assets.fetch("/assets/favicon.ico")).to eq(type: :image, crossorigin: false)
+        expect(assets.fetch("/assets/favicon.ico")).to eq(as: :image, crossorigin: false)
       end
 
       it "allows crossorigin assets inclusion in push promise assets" do
@@ -303,7 +303,7 @@ describe Hanami::Assets::Helpers do
         expect(actual).to eq(%(<link href="https://assets.hanamirb.org/assets/favicon.ico" rel="shortcut icon" type="image/x-icon">))
 
         assets = Thread.current[:__hanami_assets]
-        expect(assets.fetch("https://assets.hanamirb.org/assets/favicon.ico")).to eq(type: :image, crossorigin: true)
+        expect(assets.fetch("https://assets.hanamirb.org/assets/favicon.ico")).to eq(as: :image, crossorigin: true)
       end
     end
   end
@@ -388,7 +388,7 @@ describe Hanami::Assets::Helpers do
         expect(actual).to eq(%(<video src="/assets/movie.mp4"></video>))
 
         assets = Thread.current[:__hanami_assets]
-        expect(assets.fetch("/assets/movie.mp4")).to eq(type: :video, crossorigin: false)
+        expect(assets.fetch("/assets/movie.mp4")).to eq(as: :video, crossorigin: false)
       end
 
       it "allows crossorigin asset inclusion in push promise assets" do
@@ -396,7 +396,7 @@ describe Hanami::Assets::Helpers do
         expect(actual).to eq(%(<video src="https://assets.hanamirb.org/assets/movie.mp4"></video>))
 
         assets = Thread.current[:__hanami_assets]
-        expect(assets.fetch("https://assets.hanamirb.org/assets/movie.mp4")).to eq(type: :video, crossorigin: true)
+        expect(assets.fetch("https://assets.hanamirb.org/assets/movie.mp4")).to eq(as: :video, crossorigin: true)
       end
 
       it "allows asset inclusion in push promise assets when using block syntax" do
@@ -407,7 +407,7 @@ describe Hanami::Assets::Helpers do
         expect(actual).to eq(%(<video src="/assets/movie.mp4">\nYour browser does not support the video tag\n</video>))
 
         assets = Thread.current[:__hanami_assets]
-        expect(assets.fetch("/assets/movie.mp4")).to eq(type: :video, crossorigin: false)
+        expect(assets.fetch("/assets/movie.mp4")).to eq(as: :video, crossorigin: false)
       end
 
       it "allows asset inclusion in push promise assets when using block syntax and source tags" do
@@ -420,7 +420,7 @@ describe Hanami::Assets::Helpers do
         expect(actual).to eq(%(<video>\nYour browser does not support the video tag\n<source src="/assets/movie.mp4" type="video/mp4">\n<source src="/assets/movie.ogg" type="video/ogg">\n</video>))
 
         assets = Thread.current[:__hanami_assets]
-        expect(assets.fetch("/assets/movie.mp4")).to eq(type: :video, crossorigin: false)
+        expect(assets.fetch("/assets/movie.mp4")).to eq(as: :video, crossorigin: false)
       end
     end
   end
@@ -505,7 +505,7 @@ describe Hanami::Assets::Helpers do
         expect(actual).to eq(%(<audio src="/assets/song.ogg"></audio>))
 
         assets = Thread.current[:__hanami_assets]
-        expect(assets.fetch("/assets/song.ogg")).to eq(type: :audio, crossorigin: false)
+        expect(assets.fetch("/assets/song.ogg")).to eq(as: :audio, crossorigin: false)
       end
 
       it "allows crossorigin asset inclusion in push promise assets" do
@@ -513,7 +513,7 @@ describe Hanami::Assets::Helpers do
         expect(actual).to eq(%(<audio src="https://assets.hanamirbg.org/assets/song.ogg"></audio>))
 
         assets = Thread.current[:__hanami_assets]
-        expect(assets.fetch("https://assets.hanamirbg.org/assets/song.ogg")).to eq(type: :audio, crossorigin: true)
+        expect(assets.fetch("https://assets.hanamirbg.org/assets/song.ogg")).to eq(as: :audio, crossorigin: true)
       end
 
       it "allows asset inclusion in push promise assets when using block syntax" do
@@ -524,7 +524,7 @@ describe Hanami::Assets::Helpers do
         expect(actual).to eq(%(<audio src="/assets/song.ogg">\nYour browser does not support the audio tag\n</audio>))
 
         assets = Thread.current[:__hanami_assets]
-        expect(assets.fetch("/assets/song.ogg")).to eq(type: :audio, crossorigin: false)
+        expect(assets.fetch("/assets/song.ogg")).to eq(as: :audio, crossorigin: false)
       end
 
       it "allows asset inclusion in push promise assets when using block syntax and source tags" do
@@ -537,7 +537,7 @@ describe Hanami::Assets::Helpers do
         expect(actual).to eq(%(<audio>\nYour browser does not support the audio tag\n<source src="/assets/song.ogg" type="audio/ogg">\n<source src="/assets/song.wav" type="audio/wav">\n</audio>))
 
         assets = Thread.current[:__hanami_assets]
-        expect(assets.fetch("/assets/song.ogg")).to eq(type: :audio, crossorigin: false)
+        expect(assets.fetch("/assets/song.ogg")).to eq(as: :audio, crossorigin: false)
       end
     end
   end
@@ -577,7 +577,7 @@ describe Hanami::Assets::Helpers do
         assets = Thread.current[:__hanami_assets]
 
         expect(assets).to be_kind_of(Hash)
-        expect(assets.fetch('/assets/dashboard.js')).to eq(type: nil, crossorigin: false)
+        expect(assets.fetch('/assets/dashboard.js')).to eq(as: nil, crossorigin: false)
       end
 
       it "allows to specify asset type" do
@@ -585,7 +585,7 @@ describe Hanami::Assets::Helpers do
         assets = Thread.current[:__hanami_assets]
 
         expect(assets).to be_kind_of(Hash)
-        expect(assets.fetch('/assets/video.mp4')).to eq(type: :video, crossorigin: false)
+        expect(assets.fetch('/assets/video.mp4')).to eq(as: :video, crossorigin: false)
       end
 
       it "allows to link crossorigin asset" do
@@ -593,7 +593,7 @@ describe Hanami::Assets::Helpers do
         assets = Thread.current[:__hanami_assets]
 
         expect(assets).to be_kind_of(Hash)
-        expect(assets.fetch("https://assets.hanamirb.org/assets/video.mp4")).to eq(type: :video, crossorigin: true)
+        expect(assets.fetch("https://assets.hanamirb.org/assets/video.mp4")).to eq(as: :video, crossorigin: true)
       end
     end
   end
@@ -637,7 +637,7 @@ describe Hanami::Assets::Helpers do
         assets = Thread.current[:__hanami_assets]
 
         expect(assets).to be_kind_of(Hash)
-        expect(assets.fetch("http://localhost:2300/assets/metrics.js")).to eq(type: nil, crossorigin: false)
+        expect(assets.fetch("http://localhost:2300/assets/metrics.js")).to eq(as: nil, crossorigin: false)
       end
 
       it "allows to specify asset type" do
@@ -645,7 +645,7 @@ describe Hanami::Assets::Helpers do
         assets = Thread.current[:__hanami_assets]
 
         expect(assets).to be_kind_of(Hash)
-        expect(assets.fetch("http://localhost:2300/assets/metrics.js")).to eq(type: :script, crossorigin: false)
+        expect(assets.fetch("http://localhost:2300/assets/metrics.js")).to eq(as: :script, crossorigin: false)
       end
 
       it "allows to link crossorigin asset" do
@@ -653,7 +653,7 @@ describe Hanami::Assets::Helpers do
         assets = Thread.current[:__hanami_assets]
 
         expect(assets).to be_kind_of(Hash)
-        expect(assets.fetch("https://assets.hanamirb.org/assets/metrics.js")).to eq(type: :script, crossorigin: true)
+        expect(assets.fetch("https://assets.hanamirb.org/assets/metrics.js")).to eq(as: :script, crossorigin: true)
       end
     end
   end

--- a/spec/unit/hanami/assets/helpers_spec.rb
+++ b/spec/unit/hanami/assets/helpers_spec.rb
@@ -331,7 +331,8 @@ describe Hanami::Assets::Helpers do
 
     it 'adds source to HTTP/2 PUSH PROMISE list' do
       view.asset_path('dashboard.js')
-      expect(Thread.current[:__hanami_assets]).to include('/assets/dashboard.js')
+      expect(Thread.current[:__hanami_assets]).to be_kind_of(Hash)
+      expect(Thread.current[:__hanami_assets].fetch('/assets/dashboard.js')).to eq({})
     end
 
     describe 'cdn mode' do


### PR DESCRIPTION
Enhance the HTTP/2 Push Promise / Early Hints per-request registry.

---

As of `hanami-assets` `v0.1.0` we collect in a thread-local registry all the assets that are referenced in a HTML page via our asset helpers (eg. `javascript`, `stylesheet`, etc..).

That was designed to [HTTP/2 Push Promise](https://http2.github.io/http2-spec/#PUSH_PROMISE) to Hanami (`hanami` gem) some day.

---

HTTP/2 adoption is still low, so IETF in Oct 2017 standardized a new HTTP status: [`103 (Early Hints)`](https://datatracker.ietf.org/doc/draft-ietf-httpbis-early-hints/?include_text=1).

This backward compatible with HTTP/1.1.

A web application can send _early hints_ of the assets that are needed by to load the page. The browser can start to download them in the background.

Please notice that the web app is sending **two or more HTTP responses**:

```
HTTP/1.1 103 Early Hints
Link: </style.css>; rel=preload; as=style
Link: </script.js>; rel=preload; as=script

HTTP/1.1 200 OK
Date: Fri, 26 May 2017 10:02:11 GMT
Content-Length: 1234
Content-Type: text/html; charset=utf-8
Link: </style.css>; rel=preload; as=style
Link: </script.js>; rel=preload; as=script

<!doctype html>
[... rest of the response body is omitted from the example ...]
```

The web app can send as many as `103` responses as needed.

---

The current _thread-local_ registry was a `Set` that collected all the assets in the page. This PR turns it into a `Hash` with more informations.

Specifically, it needs to collect the type (`:as`) and if it's a cross-origin resource (`:crossorigin`).

```
HTTP/1.1 103 Early Hints
Link: </assets/application.css>; rel=preload; as=style
Link: </assets/application.js>; rel=preload; as=script
Link: <https://some-cdn.org/framework.js>; rel=preload; as=script; crossorigin

...
```

---

Given the browsers (Chrome 61) cap to `100` the maximum number of preloaded assets, so we want to be careful with the kind of resources that we want to be preloaded.

In an [example app](https://github.com/jodosha/hall_of_fame), I noticed that javascript files weren't preloaded because they were placed at the bottom of the markup, and the page loading already used all the 100 pushes for a lot of images.

Typically web pages have a lot of assets, but the most important are javascripts and stylesheets. So this PR proposes to turn on HTTP/2 Push Promise/Early Hints by default only for these two kind of assets.

Developers can manually enable that feature with a new inline option: `:push`.

---

Here's some examples:

#### Stylesheets

Eligible:

```erb
<%= stylesheet "application" %>
<%= stylesheet "https://somecdn.test/framework.css", "dashboard" %>
```

Opt-out:

```erb
<%= stylesheet "application", push: false %>
<%= stylesheet "https://somecdn.test/framework.css", "dashboard", push: false %>
```

#### Javascripts

Eligible:

```erb
<%= javascript "application" %>
<%= javascript "https://somecdn.test/framework.js", "dashboard" %>
```

Opt-out:

```erb
<%= javascript "application", push: false %>
<%= javascript "https://somecdn.test/framework.css", "dashboard", push: false %>
```

#### Audio

Opt-in:

```erb
<%= audio "song.ogg", push: true %>
```

Block syntax (pushes only `song.ogg`):

```erb
<%=
  audio do
    text "Your browser does not support the audio tag"
    source src: asset_path("song.ogg", push: :audio), type: "audio/ogg"
    source src: asset_path("song.wav"), type: "audio/wav"
  end
%>
```

#### Video

Opt-in:

```erb
<%= video "movie.mp4", push: true %>
```

Block syntax (pushes only `movie.mp4`):

```erb
<%=
  video do
    text "Your browser does not support the video tag"
    source src: asset_path("movie.mp4", push: :video), type: "video/mp4"
    source src: asset_path("movie.ogg"), type: "video/ogg"
  end
%>
```

#### Asset path

```erb
<%= asset_path "application.js", push: :script %>
```

#### Asset URL

```erb
<%= asset_url "https://somecdn.test/framework.js", push: :script %>
```

---

Ref https://trello.com/c/c4NGy33K/1-http-2-early-hints