### PR TITLE
src/href first

### DIFF
--- a/lib/hanami/assets/helpers.rb
+++ b/lib/hanami/assets/helpers.rb
@@ -343,10 +343,15 @@ module Hanami
       #
       #   # <img src="https://assets.bookshelf.org/assets/logo-28a6b886de2372ee3922fcaf3f78f2d8.png" alt="Logo">
       def image(source, options = {})
-        options[:src] = asset_path(source)
-        options[:alt] ||= Utils::String.titleize(::File.basename(source, WILDCARD_EXT))
+        options = options.reject { |k, _| k.to_sym == :src }
 
-        html.img(options)
+        attributes = {
+          src: asset_path(source),
+          alt: Utils::String.titleize(::File.basename(source, WILDCARD_EXT))
+        }
+        attributes.merge!(options)
+
+        html.img(attributes)
       end
 
       # Generate <tt>link</tt> tag application favicon.

--- a/lib/hanami/assets/helpers.rb
+++ b/lib/hanami/assets/helpers.rb
@@ -166,18 +166,22 @@ module Hanami
       #   <%= javascript 'application' %>
       #
       #   # <script src="https://assets.bookshelf.org/assets/application-28a6b886de2372ee3922fcaf3f78f2d8.js" type="text/javascript"></script>
-      def javascript(*sources, **options)
-        _safe_tags(*sources) do |source|
-          tag_options = options.dup
-          tag_options[:src] ||= _typed_asset_path(source, JAVASCRIPT_EXT)
-          tag_options[:type] ||= JAVASCRIPT_MIME_TYPE
+      def javascript(*sources, **options) # rubocop:disable Metrics/MethodLength
+        options = options.reject { |k, _| k.to_sym == :src }
 
-          if _subresource_integrity? || tag_options.include?(:integrity)
-            tag_options[:integrity] ||= _subresource_integrity_value(source, JAVASCRIPT_EXT)
-            tag_options[:crossorigin] ||= CROSSORIGIN_ANONYMOUS
+        _safe_tags(*sources) do |source|
+          attributes = {
+            src:  _typed_asset_path(source, JAVASCRIPT_EXT),
+            type: JAVASCRIPT_MIME_TYPE
+          }
+          attributes.merge!(options)
+
+          if _subresource_integrity? || attributes.include?(:integrity)
+            attributes[:integrity] ||= _subresource_integrity_value(source, JAVASCRIPT_EXT)
+            attributes[:crossorigin] ||= CROSSORIGIN_ANONYMOUS
           end
 
-          html.script(**tag_options).to_s
+          html.script(**attributes).to_s
         end
       end
 

--- a/lib/hanami/assets/helpers.rb
+++ b/lib/hanami/assets/helpers.rb
@@ -410,11 +410,16 @@ module Hanami
       #
       #   # <link href="https://assets.bookshelf.org/assets/favicon-28a6b886de2372ee3922fcaf3f78f2d8.ico" rel="shortcut icon" type="image/x-icon">
       def favicon(source = DEFAULT_FAVICON, options = {})
-        options[:href]   = asset_path(source)
-        options[:rel]  ||= FAVICON_REL
-        options[:type] ||= FAVICON_MIME_TYPE
+        options = options.reject { |k, _| k.to_sym == :href }
 
-        html.link(options)
+        attributes = {
+          href: asset_path(source),
+          rel:  FAVICON_REL,
+          type: FAVICON_MIME_TYPE
+        }
+        attributes.merge!(options)
+
+        html.link(attributes)
       end
 
       # Generate <tt>video</tt> tag for given source

--- a/lib/hanami/assets/helpers.rb
+++ b/lib/hanami/assets/helpers.rb
@@ -257,19 +257,23 @@ module Hanami
       #   <%= stylesheet 'application' %>
       #
       #   # <link href="https://assets.bookshelf.org/assets/application-28a6b886de2372ee3922fcaf3f78f2d8.css" type="text/css" rel="stylesheet">
-      def stylesheet(*sources, **options) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-        _safe_tags(*sources) do |source|
-          tag_options = options.dup
-          tag_options[:href] ||= _typed_asset_path(source, STYLESHEET_EXT)
-          tag_options[:type] ||= STYLESHEET_MIME_TYPE
-          tag_options[:rel] ||= STYLESHEET_REL
+      def stylesheet(*sources, **options) # rubocop:disable Metrics/MethodLength
+        options = options.reject { |k, _| k.to_sym == :href }
 
-          if _subresource_integrity? || tag_options.include?(:integrity)
-            tag_options[:integrity] ||= _subresource_integrity_value(source, STYLESHEET_EXT)
-            tag_options[:crossorigin] ||= CROSSORIGIN_ANONYMOUS
+        _safe_tags(*sources) do |source|
+          attributes = {
+            href: _typed_asset_path(source, STYLESHEET_EXT),
+            type: STYLESHEET_MIME_TYPE,
+            rel:  STYLESHEET_REL
+          }
+          attributes.merge!(options)
+
+          if _subresource_integrity? || attributes.include?(:integrity)
+            attributes[:integrity] ||= _subresource_integrity_value(source, STYLESHEET_EXT)
+            attributes[:crossorigin] ||= CROSSORIGIN_ANONYMOUS
           end
 
-          html.link(**tag_options).to_s
+          html.link(**attributes).to_s
         end
       end
 

--- a/spec/unit/hanami/assets/helpers_spec.rb
+++ b/spec/unit/hanami/assets/helpers_spec.rb
@@ -24,23 +24,28 @@ describe Hanami::Assets::Helpers do
 
     it 'renders <script> tag with a defer attribute' do
       actual = DefaultView.new.javascript('feature-a', defer: true)
-      expect(actual).to eq(%(<script defer="defer" src="/assets/feature-a.js" type="text/javascript"></script>))
+      expect(actual).to eq(%(<script src="/assets/feature-a.js" type="text/javascript" defer="defer"></script>))
     end
 
     it 'renders <script> tag with an integrity attribute' do
       actual = DefaultView.new.javascript('feature-a', integrity: 'sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC')
-      expect(actual).to eq(%(<script integrity="sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC" src="/assets/feature-a.js" type="text/javascript" crossorigin="anonymous"></script>))
+      expect(actual).to eq(%(<script src="/assets/feature-a.js" type="text/javascript" integrity="sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC" crossorigin="anonymous"></script>))
     end
 
     it 'renders <script> tag with a crossorigin attribute' do
       actual = DefaultView.new.javascript('feature-a', integrity: 'sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC', crossorigin: 'use-credentials')
-      expect(actual).to eq(%(<script integrity="sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC" crossorigin="use-credentials" src="/assets/feature-a.js" type="text/javascript"></script>))
+      expect(actual).to eq(%(<script src="/assets/feature-a.js" type="text/javascript" integrity="sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC" crossorigin="use-credentials"></script>))
+    end
+
+    it 'ignores src passed as an option' do
+      actual = DefaultView.new.javascript('feature-a', src: 'wrong')
+      expect(actual).to eq(%(<script src="/assets/feature-a.js" type="text/javascript"></script>))
     end
 
     describe 'async option' do
       it 'renders <script> tag with an async=true if async option is true' do
         actual = DefaultView.new.javascript('feature-a', async: true)
-        expect(actual).to eq(%(<script async="async" src="/assets/feature-a.js" type="text/javascript"></script>))
+        expect(actual).to eq(%(<script src="/assets/feature-a.js" type="text/javascript" async="async"></script>))
       end
 
       it 'renders <script> tag without an async=true if async option is false' do

--- a/spec/unit/hanami/assets/helpers_spec.rb
+++ b/spec/unit/hanami/assets/helpers_spec.rb
@@ -144,12 +144,17 @@ describe Hanami::Assets::Helpers do
 
     it 'custom alt' do
       actual = view.image('application.jpg', alt: 'My Alt').to_s
-      expect(actual).to eq(%(<img alt="My Alt" src="/assets/application.jpg">))
+      expect(actual).to eq(%(<img src="/assets/application.jpg" alt="My Alt">))
     end
 
     it 'custom data attribute' do
       actual = view.image('application.jpg', 'data-user-id' => 5).to_s
-      expect(actual).to eq(%(<img data-user-id="5" src="/assets/application.jpg" alt="Application">))
+      expect(actual).to eq(%(<img src="/assets/application.jpg" alt="Application" data-user-id="5">))
+    end
+
+    it 'ignores src passed as an option' do
+      actual = view.image('application.jpg', src: 'wrong').to_s
+      expect(actual).to eq(%(<img src="/assets/application.jpg" alt="Application">))
     end
 
     describe 'cdn mode' do

--- a/spec/unit/hanami/assets/helpers_spec.rb
+++ b/spec/unit/hanami/assets/helpers_spec.rb
@@ -95,12 +95,17 @@ describe Hanami::Assets::Helpers do
 
     it 'renders <link> tag with an integrity attribute' do
       actual = DefaultView.new.stylesheet('main', integrity: 'sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC')
-      expect(actual).to eq(%(<link integrity=\"sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC\" href=\"/assets/main.css\" type=\"text/css\" rel=\"stylesheet\" crossorigin=\"anonymous\">))
+      expect(actual).to eq(%(<link href="/assets/main.css" type="text/css" rel="stylesheet" integrity="sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC" crossorigin="anonymous">))
     end
 
     it 'renders <link> tag with a crossorigin attribute' do
       actual = DefaultView.new.stylesheet('main', integrity: 'sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC', crossorigin: 'use-credentials')
-      expect(actual).to eq(%(<link integrity="sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC" crossorigin="use-credentials" href="/assets/main.css" type="text/css" rel="stylesheet">))
+      expect(actual).to eq(%(<link href="/assets/main.css" type="text/css" rel="stylesheet" integrity="sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC" crossorigin="use-credentials">))
+    end
+
+    it 'ignores href passed as an option' do
+      actual = DefaultView.new.stylesheet('main', href: 'wrong')
+      expect(actual).to eq(%(<link href="/assets/main.css" type="text/css" rel="stylesheet">))
     end
 
     describe 'subresource_integrity mode' do

--- a/spec/unit/hanami/assets/helpers_spec.rb
+++ b/spec/unit/hanami/assets/helpers_spec.rb
@@ -182,7 +182,12 @@ describe Hanami::Assets::Helpers do
 
     it 'renders with HTML attributes' do
       actual = view.favicon('favicon.png', rel: 'icon', type: 'image/png').to_s
-      expect(actual).to eq(%(<link rel="icon" type="image/png" href="/assets/favicon.png">))
+      expect(actual).to eq(%(<link href="/assets/favicon.png" rel="icon" type="image/png">))
+    end
+
+    it 'ignores href passed as an option' do
+      actual = view.favicon('favicon.png', href: 'wrong').to_s
+      expect(actual).to eq(%(<link href="/assets/favicon.png" rel="shortcut icon" type="image/x-icon">))
     end
 
     describe 'cdn mode' do


### PR DESCRIPTION
This PR makes two changes to the asset helpers:

    Make it a consistent behaviour to ignore the src or href attribute when passed in the options of an helper (currently, script and stylesheet let it override their source value), and complete the specs to verify it.
    Always output the src or href attribute first. This is a purely cosmetic change that improves readability of the generated HTML code.

Since they both change the same lines of code, they are "packaged" together. If point 2 is rejected, I will make a new PR with just the fixes for point 1.