### PR TITLE
Disable nested assets by default

### DIFF
--- a/lib/hanami/assets/compiler.rb
+++ b/lib/hanami/assets/compiler.rb
@@ -177,17 +177,26 @@ module Hanami
         relative_destination_name(name: Pathname.new(result), add_prefix: false)
       end
 
-      # @since 0.1.0
+      # @since 1.3.0
       # @api private
       def destination_name
-        result = @name.relative? ? relative_destination_name : absolute_destination_name
-        result = result.to_s
+        result = destination_path
 
         if compile?
           result.scan(/\A[[[:alnum:]][\-\_]]*\.[[\w]]*/).first || result
         else
           result
         end
+      end
+
+      # @since 1.3.1
+      # @api private
+      def destination_path
+        if @configuration.nested
+          @name.relative? ? relative_destination_name : absolute_destination_name
+        else
+          ::File.basename(@name)
+        end.to_s
       end
 
       # @since 0.1.0

--- a/lib/hanami/assets/configuration.rb
+++ b/lib/hanami/assets/configuration.rb
@@ -129,6 +129,17 @@ module Hanami
         end
       end
 
+      # Support for nested path
+      #
+      # @since 1.3.1
+      def nested(value = nil)
+        if value.nil?
+          @nested
+        else
+          @nested = !!value # rubocop:disable Style/DoubleNegation
+        end
+      end
+
       # Subresource integrity mode
       #
       # Determine if the helpers should generate the integrity attribute for an
@@ -506,6 +517,7 @@ module Hanami
           c.subresource_integrity = subresource_integrity
           c.cdn                   = cdn
           c.compile               = compile
+          c.nested                = nested
           c.public_directory      = public_directory
           c.manifest              = manifest
           c.sources               = sources.dup
@@ -526,6 +538,7 @@ module Hanami
         @cdn                   = false
         @fingerprint           = false
         @compile               = false
+        @nested                = false
         @base_url              = nil
         @destination_directory = nil
         @public_manifest       = Config::NullManifest.new(self)
@@ -568,6 +581,10 @@ module Hanami
       # @since 0.1.0
       # @api private
       attr_writer :compile
+
+      # @since 1.3.1
+      # @api private
+      attr_writer :nested
 
       # @since 0.1.0
       # @api private

--- a/spec/integration/hanami/assets/compiler_spec.rb
+++ b/spec/integration/hanami/assets/compiler_spec.rb
@@ -52,7 +52,19 @@ RSpec.describe 'Compiler' do
     expect(target.stat.mode.to_s(8)).to eq('100644')
   end
 
+  # Bug https://github.com/hanami/assets/issues/95
+  it 'does not find nested asset when nested setting is set to false (default)' do
+    @config.nested false
+    Hanami::Assets::Compiler.compile(@config, 'helper.js')
+
+    target = @config.public_directory.join('assets', 'bootstrap', 'helper.js')
+    expect(target.read).to match %(var helper = {})
+    expect(target.stat.mode.to_s(8)).to eq('100644')
+  end
+
+  # Bug https://github.com/hanami/assets/issues/95
   it 'copies nested asset from nested source to destination' do
+    @config.nested true
     Hanami::Assets::Compiler.compile(@config, 'bootstrap/helper.js')
 
     target = @config.public_directory.join('assets', 'bootstrap', 'helper.js')

--- a/spec/unit/hanami/assets/configuration_spec.rb
+++ b/spec/unit/hanami/assets/configuration_spec.rb
@@ -148,6 +148,17 @@ RSpec.describe Hanami::Assets::Configuration do
     end
   end
 
+  describe '#nested' do
+    it 'is false by default' do
+      expect(@configuration.nested).to eq(false)
+    end
+
+    it 'allows to set a value' do
+      @configuration.nested               true
+      expect(@configuration.nested).to eq(true)
+    end
+  end
+
   describe '#sources' do
     it 'is empty by default' do
       expect(@configuration.sources).to be_empty
@@ -622,6 +633,7 @@ RSpec.describe Hanami::Assets::Configuration do
       @configuration.cdn                   true
       @configuration.subresource_integrity true
       @configuration.compile               true
+      @configuration.nested                true
       @configuration.scheme                'ftp'
       @configuration.host                  'hanamirb.org'
       @configuration.port                  '8080'
@@ -640,6 +652,7 @@ RSpec.describe Hanami::Assets::Configuration do
       expect(@config.cdn).to                   eq(true)
       expect(@config.subresource_integrity).to eq(true)
       expect(@config.compile).to               eq(true)
+      expect(@config.nested).to                eq(true)
       expect(@config.scheme).to                eq('ftp')
       expect(@config.host).to                  eq('hanamirb.org')
       expect(@config.port).to                  eq('8080')
@@ -656,6 +669,7 @@ RSpec.describe Hanami::Assets::Configuration do
       @config.cdn                   false
       @config.subresource_integrity false
       @config.compile               false
+      @config.nested                false
       @config.scheme                'mailto'
       @config.host                  'example.org'
       @config.port                  '9091'
@@ -670,6 +684,7 @@ RSpec.describe Hanami::Assets::Configuration do
       expect(@config.cdn).to                   eq(false)
       expect(@config.subresource_integrity).to eq(false)
       expect(@config.compile).to               eq(false)
+      expect(@config.nested).to                eq(false)
       expect(@config.scheme).to                eq('mailto')
       expect(@config.host).to                  eq('example.org')
       expect(@config.port).to                  eq('9091')
@@ -684,6 +699,7 @@ RSpec.describe Hanami::Assets::Configuration do
       expect(@configuration.cdn).to                   eq(true)
       expect(@configuration.subresource_integrity).to eq(true)
       expect(@configuration.compile).to               eq(true)
+      expect(@configuration.nested).to                eq(true)
       expect(@configuration.scheme).to                eq('ftp')
       expect(@configuration.host).to                  eq('hanamirb.org')
       expect(@configuration.port).to                  eq('8080')


### PR DESCRIPTION
## Fix

Keeps nested attributes as feature, but disable it by default, to keep backward compatibility with 1.2.x.

People who want to use nested attributes must enable it:

##### Standalone

```ruby
Hanami::Assets.configure do
  nested true
end
```

or

##### Full stack

```ruby
# apps/web/application.rb

module Web
  class Application < Hanami::Application
    configure do
      assets do
        nested true
      end
    end
  end
end
```

## Manual testing

### Default behavior (compatible with 1.2.x)

  1. Install `hanami` `1.3.0` (`gem install hanami -v 1.3.0`)
  1. Generate a new project (`hanami new bookshelf && cd bookshelf && bundle`)
  1. Create a nested directory for an asset (`mkdir -p apps/web/assets/stylesheets/nested`)
  1. Add a stylesheet (`apps/web/assets/stylesheets/nested/style.css`) with this content: `body { background-color: yellow; }`
  1. Reference the stylesheet from the application template (`apps/web/templates/application.html.erb`): `<%= stylesheet "nested/style" %>`
  1. Generate an action: `bundle exec hanami generate action web home#index --url=/`
  1. Start the server
  1. Visit `/`, you should **NOT** see the yellow background

### New behavior (introduced with 1.3.0)

  1. From the previous step, stop the server
  1. Delete the public directory (`rm -rf public/assets`)
  1. Edit `apps/web/application.rb`, by setting `nested true`
  1. Start the server
  1. Visit again, you **SHOULD** see the yellow background

---

Fixes https://github.com/hanami/assets/issues/95