### PR TITLE
Use SassC in place of Sass (EOL)

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ handling: `.css` for stylesheets.
 The second one is optional and it's for a preprocessor: `.scss` for Sass.
 
 ```ruby
-require 'sass'
+require 'sassc'
 require 'hanami/assets'
 
 Hanami::Assets.configure do
@@ -353,7 +353,7 @@ Hanami can use the following compressors (aka minifiers) for stylesheets.
 
   * `:builtin` - Ruby based compressor. It doesn't require any external gem. It's fast, but not an efficient compressor.
   * `:yui` - [YUI Compressor](http://yui.github.io/yuicompressor), it depends on [`yui-compressor`](https://rubygems.org/gems/yui-compressor) gem and it requires Java 1.4+
-  * `:sass` - [Sass](http://sass-lang.com/), it depends on [`sass`](https://rubygems.org/gems/sass) gem
+  * `:sass` - [Sass](http://sass-lang.com/), it depends on [`sassc`](https://rubygems.org/gems/sassc) gem
 
 ```ruby
 Hanami::Assets.configure do

--- a/hanami-assets.gemspec
+++ b/hanami-assets.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'yui-compressor',   '~> 0.12'
   spec.add_development_dependency 'uglifier',         '~> 2.7'
   spec.add_development_dependency 'closure-compiler', '~> 1.1'
-  spec.add_development_dependency 'sass',             '~> 3.4'
+  spec.add_development_dependency 'sassc',            '~> 1.1'
 
   spec.add_development_dependency 'coffee-script',    '~> 2.3'
   spec.add_development_dependency 'babel-transpiler', '~> 0.7'

--- a/hanami-assets.gemspec
+++ b/hanami-assets.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'yui-compressor',   '~> 0.12'
   spec.add_development_dependency 'uglifier',         '~> 2.7'
   spec.add_development_dependency 'closure-compiler', '~> 1.1'
-  spec.add_development_dependency 'sassc',            '~> 1.1'
+  spec.add_development_dependency 'sassc',            '~> 2.0'
 
   spec.add_development_dependency 'coffee-script',    '~> 2.3'
   spec.add_development_dependency 'babel-transpiler', '~> 0.7'

--- a/lib/hanami/assets/compilers/sass.rb
+++ b/lib/hanami/assets/compilers/sass.rb
@@ -31,14 +31,12 @@ module Hanami
 
         # @since 0.3.0
         # @api private
-        def dependencies
-          engine.dependencies.map { |d| d.options[:filename] }
+        def engine
+          ::SassC::Engine.new(to_be_compiled, load_paths: load_paths, cache_location: CACHE_LOCATION)
         end
 
-        # @since 0.3.0
-        # @api private
-        def engine
-          ::SassC::Engine.for_file(source.to_s, load_paths: load_paths, cache_location: CACHE_LOCATION)
+        def to_be_compiled
+          ::File.read(source.to_s)
         end
       end
     end

--- a/lib/hanami/assets/compilers/sass.rb
+++ b/lib/hanami/assets/compilers/sass.rb
@@ -38,7 +38,7 @@ module Hanami
         # @since 0.3.0
         # @api private
         def engine
-          ::Sass::Engine.for_file(source.to_s, load_paths: load_paths, cache_location: CACHE_LOCATION)
+          ::SassC::Engine.for_file(source.to_s, load_paths: load_paths, cache_location: CACHE_LOCATION)
         end
       end
     end

--- a/lib/hanami/assets/compilers/sass.rb
+++ b/lib/hanami/assets/compilers/sass.rb
@@ -35,6 +35,8 @@ module Hanami
           ::SassC::Engine.new(to_be_compiled, load_paths: load_paths, cache_location: CACHE_LOCATION)
         end
 
+        # @since x.x.x
+        # @api private
         def to_be_compiled
           ::File.read(source.to_s)
         end

--- a/lib/hanami/assets/compilers/sass.rb
+++ b/lib/hanami/assets/compilers/sass.rb
@@ -21,27 +21,31 @@ module Hanami
         # @since 0.3.0
         # @api private
         def renderer
-          Tilt.new(source, nil, load_paths: load_paths)
+          @renderer ||=
+            ::SassC::Engine.new(
+              to_be_compiled,
+              syntax: target_syntax,
+              load_paths: load_paths
+            )
         end
 
         # @since 0.3.0
         # @api private
         def dependencies
-          engine.render
-          engine.dependencies.map { |d| d.options[:filename] }
+          renderer.dependencies.map(&:filename)
         end
 
-        # @since 0.3.0
+        # @since 1.3.2
         # @api private
-        def engine
-          @engine ||= ::SassC::Engine.new(
-            to_be_compiled,
-            load_paths: load_paths,
-            syntax: (:sass if ::File.extname(source.to_s) == ".sass")
-          )
+        def target_syntax
+          if source.extname =~ /sass/
+            :sass
+          else
+            :scss
+          end
         end
 
-        # @since x.x.x
+        # @since 1.3.2
         # @api private
         def to_be_compiled
           ::File.read(source.to_s)

--- a/lib/hanami/assets/compilers/sass.rb
+++ b/lib/hanami/assets/compilers/sass.rb
@@ -31,8 +31,20 @@ module Hanami
 
         # @since 0.3.0
         # @api private
+        def dependencies
+          engine.render
+          engine.dependencies.map { |d| d.options[:filename] }
+        end
+
+        # @since 0.3.0
+        # @api private
         def engine
-          ::SassC::Engine.new(to_be_compiled, load_paths: load_paths, cache_location: CACHE_LOCATION)
+          @engine ||= ::SassC::Engine.new(
+            to_be_compiled,
+            load_paths: load_paths,
+            cache_location: CACHE_LOCATION,
+            syntax: (:sass if ::File.extname(source.to_s) == ".sass")
+          )
         end
 
         # @since x.x.x

--- a/lib/hanami/assets/compilers/sass.rb
+++ b/lib/hanami/assets/compilers/sass.rb
@@ -38,7 +38,7 @@ module Hanami
         # @since 1.3.2
         # @api private
         def target_syntax
-          if source.extname =~ /sass/
+          if source.extname =~ /sass\z/.freeze
             :sass
           else
             :scss

--- a/lib/hanami/assets/compilers/sass.rb
+++ b/lib/hanami/assets/compilers/sass.rb
@@ -10,11 +10,6 @@ module Hanami
         # @api private
         EXTENSIONS = /\.(sass|scss)\z/.freeze
 
-        # @since 0.1.0
-        # @api private
-        CACHE_LOCATION = Pathname(Hanami.respond_to?(:root) ? # rubocop:disable Style/MultilineTernaryOperator
-                                  Hanami.root : Dir.pwd).join('tmp', 'sass-cache')
-
         # @since 0.3.0
         # @api private
         def self.eligible?(name)
@@ -26,7 +21,7 @@ module Hanami
         # @since 0.3.0
         # @api private
         def renderer
-          Tilt.new(source, nil, load_paths: load_paths, cache_location: CACHE_LOCATION)
+          Tilt.new(source, nil, load_paths: load_paths)
         end
 
         # @since 0.3.0
@@ -42,7 +37,6 @@ module Hanami
           @engine ||= ::SassC::Engine.new(
             to_be_compiled,
             load_paths: load_paths,
-            cache_location: CACHE_LOCATION,
             syntax: (:sass if ::File.extname(source.to_s) == ".sass")
           )
         end

--- a/lib/hanami/assets/compressors/sass_stylesheet.rb
+++ b/lib/hanami/assets/compressors/sass_stylesheet.rb
@@ -23,7 +23,7 @@ module Hanami
         # @since 0.1.0
         # @api private
         def initialize
-          @compressor = Sass::Engine
+          @compressor = SassC::Engine
         end
 
         # @since 0.1.0

--- a/lib/hanami/assets/compressors/sass_stylesheet.rb
+++ b/lib/hanami/assets/compressors/sass_stylesheet.rb
@@ -6,7 +6,7 @@ module Hanami
     module Compressors
       # Sass compressor for stylesheet
       #
-      # It depends on <tt>sass</tt> gem.
+      # It depends on <tt>sassc</tt> gem.
       #
       # @since 0.1.0
       # @api private
@@ -14,12 +14,6 @@ module Hanami
       # @see http://sass-lang.com
       # @see https://rubygems.org/gems/sass
       class SassStylesheet < Stylesheet
-        # @since 0.1.0
-        # @api private
-        #
-        # FIXME This is the same logic that we have for Hanami::Assets::Compiler
-        SASS_CACHE_LOCATION = Pathname(Hanami.respond_to?(:root) ? # rubocop:disable Style/MultilineTernaryOperator
-                                       Hanami.root : Dir.pwd).join('tmp', 'sass-cache')
         # @since 0.1.0
         # @api private
         def initialize
@@ -30,7 +24,7 @@ module Hanami
         # @api private
         def compress(filename)
           compressor.new(read(filename), filename: filename, syntax: :scss,
-                                         style: :compressed, cache_location: SASS_CACHE_LOCATION).render
+                                         style: :compressed).render
         end
       end
     end

--- a/lib/hanami/assets/compressors/sass_stylesheet.rb
+++ b/lib/hanami/assets/compressors/sass_stylesheet.rb
@@ -27,7 +27,7 @@ module Hanami
             read(filename),
             filename: filename,
             syntax: :scss,
-            style: :compressed,
+            style: :compressed
           ).render
         end
       end

--- a/lib/hanami/assets/compressors/sass_stylesheet.rb
+++ b/lib/hanami/assets/compressors/sass_stylesheet.rb
@@ -26,21 +26,9 @@ module Hanami
           compressor.new(
             read(filename),
             filename: filename,
-            syntax: target_syntax(filename),
+            syntax: :scss,
             style: :compressed,
           ).render
-        end
-
-        private
-
-        # @since 1.3.2
-        # @api private
-        def target_syntax(filename)
-          if File.extname(filename) =~ /sass/
-            :sass
-          else
-            :scss
-          end
         end
       end
     end

--- a/lib/hanami/assets/compressors/sass_stylesheet.rb
+++ b/lib/hanami/assets/compressors/sass_stylesheet.rb
@@ -1,5 +1,5 @@
 require 'hanami/assets/compressors/stylesheet'
-require 'sass'
+require 'sassc'
 
 module Hanami
   module Assets
@@ -23,8 +23,24 @@ module Hanami
         # @since 0.1.0
         # @api private
         def compress(filename)
-          compressor.new(read(filename), filename: filename, syntax: :scss,
-                                         style: :compressed).render
+          compressor.new(
+            read(filename),
+            filename: filename,
+            syntax: target_syntax(filename),
+            style: :compressed,
+          ).render
+        end
+
+        private
+
+        # @since 1.3.2
+        # @api private
+        def target_syntax(filename)
+          if File.extname(filename) =~ /sass/
+            :sass
+          else
+            :scss
+          end
         end
       end
     end

--- a/lib/hanami/assets/configuration.rb
+++ b/lib/hanami/assets/configuration.rb
@@ -233,7 +233,7 @@ module Hanami
       #
       #   * <tt>:builtin</tt> - Ruby based compressor. It doesn't require any external gem. It's fast, but not an efficient compressor.
       #   * <tt>:yui</tt> - YUI-Compressor, it depends on <tt>yui-compressor</tt> gem and requires Java 1.4+
-      #   * <tt>:sass</tt> - Sass, it depends on <tt>sass</tt> gem
+      #   * <tt>:sass</tt> - Sass, it depends on <tt>sassc</tt> gem
       #
       # @param value [Symbol,#compress] the compressor
       #
@@ -243,7 +243,7 @@ module Hanami
       # @see https://rubygems.org/gems/yui-compressor
       #
       # @see http://sass-lang.com
-      # @see https://rubygems.org/gems/sass
+      # @see https://rubygems.org/gems/sassc
       #
       # @example YUI Compressor
       #   require 'hanami/assets'

--- a/spec/integration/hanami/assets/compiler_spec.rb
+++ b/spec/integration/hanami/assets/compiler_spec.rb
@@ -208,15 +208,6 @@ RSpec.describe 'Compiler' do
     expect(target.read).to match %(body {\n  font: 100% Helvetica, sans-serif;\n  color: #fff; }\n)
   end
 
-  it 'uses defined sass cache directory' do
-    directory = Pathname.new(Dir.pwd).join('tmp', 'sass-cache')
-    directory.rmtree if directory.exist?
-
-    Hanami::Assets::Compiler.compile(@config, 'compile-sass.css')
-
-    expect(directory.exist?).to eq(true)
-  end
-
   it 'compiles scss asset if direct dependency has changed' do
     dependency = TestFile.new(path: '_background.scss') do
       write 'body { background-color: purple; }'

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -1,5 +1,5 @@
 require 'erb'
-require 'sass'
+require 'sassc'
 require 'coffee_script'
 require 'hanami/view'
 require 'tilt/erb'


### PR DESCRIPTION
The ruby-sass gem has been emitting this warning for a while when
installing gems:

```bash
Post-install message from sass:

Ruby Sass is deprecated and will be unmaintained as of 26 March 2019.

* If you use Sass as a command-line tool, we recommend using Dart Sass, the new
  primary implementation: https://sass-lang.com/install

* If you use Sass as a plug-in for a Ruby web framework, we recommend using the
  sassc gem: https://github.com/sass/sassc-ruby#readme

* For more details, please refer to the Sass blog:
  http://sass.logdown.com/posts/7081811
```

Per these instructions, I'm replacing ruby-sass with sassc-ruby.

This should close #101, and at least move things forward for https://github.com/hanami/hanami/issues/955