### PR TITLE
sassc should be a runtime dependency

### DIFF
--- a/hanami-assets.gemspec
+++ b/hanami-assets.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'hanami-utils',    '~> 1.3'
   spec.add_runtime_dependency 'hanami-helpers',  '~> 1.3'
   spec.add_runtime_dependency 'tilt',            '~> 2.0', '>= 2.0.2'
-  spec.add_runtime_dependency 'sassc',           '~> 2.0'
 
   spec.add_development_dependency 'bundler',          '>= 1.6', '< 3'
   spec.add_development_dependency 'rake',             '~> 12.0'
@@ -32,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'yui-compressor',   '~> 0.12'
   spec.add_development_dependency 'uglifier',         '~> 2.7'
   spec.add_development_dependency 'closure-compiler', '~> 1.1'
+  spec.add_development_dependency 'sassc',            '~> 2.0'
 
   spec.add_development_dependency 'coffee-script',    '~> 2.3'
   spec.add_development_dependency 'babel-transpiler', '~> 0.7'

--- a/hanami-assets.gemspec
+++ b/hanami-assets.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'hanami-utils',    '~> 1.3'
   spec.add_runtime_dependency 'hanami-helpers',  '~> 1.3'
   spec.add_runtime_dependency 'tilt',            '~> 2.0', '>= 2.0.2'
+  spec.add_runtime_dependency 'sassc',           '~> 2.0'
 
   spec.add_development_dependency 'bundler',          '>= 1.6', '< 3'
   spec.add_development_dependency 'rake',             '~> 12.0'
@@ -31,7 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'yui-compressor',   '~> 0.12'
   spec.add_development_dependency 'uglifier',         '~> 2.7'
   spec.add_development_dependency 'closure-compiler', '~> 1.1'
-  spec.add_development_dependency 'sassc',            '~> 2.0'
 
   spec.add_development_dependency 'coffee-script',    '~> 2.3'
   spec.add_development_dependency 'babel-transpiler', '~> 0.7'

--- a/lib/hanami/assets/compilers/sass.rb
+++ b/lib/hanami/assets/compilers/sass.rb
@@ -21,6 +21,7 @@ module Hanami
         # @since 0.3.0
         # @api private
         def renderer
+          require 'sassc' unless defined? SassC
           @renderer ||=
             ::SassC::Engine.new(
               source.read,


### PR DESCRIPTION
since #102, there's `require "sassc"` in the code now which makes the gem a runtime dependency.

see https://github.com/hanami/assets/pull/102#issuecomment-523056101.