### PR TITLE
Fix asset desitination name when nested true.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ end
 
 gem 'hanami-utils',   '~> 1.3', git: 'https://github.com/hanami/utils.git',   branch: 'master'
 gem 'hanami-helpers', '~> 1.3', git: 'https://github.com/hanami/helpers.git', branch: 'master'
-gem 'hanami-view',    '~> 1.3', git: 'https://github.com/hanami/view.git',    branch: 'master'
+gem 'hanami-view',    '~> 1.3', git: 'https://github.com/hanami/view.git',    branch: '1.x-master'
 
 gem 'hanami-emberjs',        path: 'spec/support/fixtures/hanami-emberjs',        require: false
 gem 'hanami-compass',        path: 'spec/support/fixtures/hanami-compass',        require: false

--- a/lib/hanami/assets/compiler.rb
+++ b/lib/hanami/assets/compiler.rb
@@ -183,7 +183,7 @@ module Hanami
         result = destination_path
 
         if compile?
-          result.scan(/\A[[[:alnum:]][\-\_]]*\.[[\w]]*/).first || result
+          result.scan(/\A[[[[:alnum:]][\-\_]]*\/]*[[[:alnum:]][\-\_]]*\.[[\w]]*/).first || result
         else
           result
         end

--- a/spec/integration/hanami/assets/compiler_spec.rb
+++ b/spec/integration/hanami/assets/compiler_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe 'Compiler' do
   # Bug https://github.com/hanami/assets/issues/95
   it 'copies asset from nested source to non-nested destination when "nested" set to false (default)' do
     @config.nested false
-    Hanami::Assets::Compiler.compile(@config, 'bootstrap/helper.js')
+    Hanami::Assets::Compiler.compile(@config, 'bootstrap/helper.js.es6')
 
     target = @config.public_directory.join('assets', 'helper.js')
     expect(target.read).to match %(var helper = {})
@@ -65,7 +65,7 @@ RSpec.describe 'Compiler' do
   # Bug https://github.com/hanami/assets/issues/95
   it 'copies asset from nested source to nested destination when "nested" set to true' do
     @config.nested true
-    Hanami::Assets::Compiler.compile(@config, 'bootstrap/helper.js')
+    Hanami::Assets::Compiler.compile(@config, 'bootstrap/helper.js.es6')
 
     target = @config.public_directory.join('assets', 'bootstrap', 'helper.js')
     expect(target.read).to match %(var helper = {})

--- a/spec/support/fixtures/javascripts/bootstrap/helper.js.es6
+++ b/spec/support/fixtures/javascripts/bootstrap/helper.js.es6
@@ -1,0 +1,1 @@
+var helper = {}


### PR DESCRIPTION
Fixes #114 

Fix regex for nested asset.
And I change Gemfile because `bundle install` is failed caused by hanami-view version.

### before

`apps/web/assets/javascripts/sessions/form.js.es6` → `public/assets/web/sessions/form.js.es6`

### after
`apps/web/assets/javascripts/sessions/form.js.es6` → `public/assets/web/sessions/form.js`