### PR TITLE
Replace sassc with sass-embedded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Assets management for Ruby web applications
 
 ## v2.0.0.alpha1 (unreleased)
 ### Changed
+- [Natsuki Natsume] Replace `sassc` with `sass-embedded` gem, because `libsass` is deprecated
 - [Luca Guidi] Drop support for Ruby: MRI 2.3, 2.4, and 2.5
 
 ## v1.3.5 - 2021-01-14

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ handling: `.css` for stylesheets.
 The second one is optional and it's for a preprocessor: `.scss` for Sass.
 
 ```ruby
-require 'sassc'
+require 'sass-embedded'
 require 'hanami/assets'
 
 Hanami::Assets.configure do
@@ -230,7 +230,7 @@ public/
 
 ### Preprocessors engines
 
-`Hanami::Assets` uses [Tilt](https://github.com/rtomayko/tilt) to provide support for the most common preprocessors, such as [Sass](http://sass-lang.com/) (including `sassc-ruby`), [Less](http://lesscss.org/), [ES6](https://babeljs.io/), [JSX](https://jsx.github.io/), [CoffeScript](http://coffeescript.org), [Opal](http://opalrb.com), [Handlebars](http://handlebarsjs.com), [JBuilder](https://github.com/rails/jbuilder).
+`Hanami::Assets` uses [Tilt](https://github.com/rtomayko/tilt) to provide support for the most common preprocessors, such as [Sass](http://sass-lang.com/) (including `sass-embedded`), [Less](http://lesscss.org/), [ES6](https://babeljs.io/), [JSX](https://jsx.github.io/), [CoffeScript](http://coffeescript.org), [Opal](http://opalrb.com), [Handlebars](http://handlebarsjs.com), [JBuilder](https://github.com/rails/jbuilder).
 
 In order to use one or more of them, be sure to add the corresponding gem to your `Gemfile` and require the library.
 
@@ -352,7 +352,7 @@ Hanami can use the following compressors (aka minifiers) for stylesheets.
 
   * `:builtin` - Ruby based compressor. It doesn't require any external gem. It's fast, but not an efficient compressor.
   * `:yui` - [YUI Compressor](http://yui.github.io/yuicompressor), it depends on [`yui-compressor`](https://rubygems.org/gems/yui-compressor) gem and it requires Java 1.4+
-  * `:sass` - [Sass](http://sass-lang.com/), it depends on [`sassc`](https://rubygems.org/gems/sassc) gem
+  * `:sass` - [Sass](http://sass-lang.com/), it depends on [`sass-embedded`](https://rubygems.org/gems/sass-embedded) gem
 
 ```ruby
 Hanami::Assets.configure do

--- a/hanami-assets.gemspec
+++ b/hanami-assets.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'yui-compressor',   '~> 0.12'
   spec.add_development_dependency 'uglifier',         '~> 2.7'
   spec.add_development_dependency 'closure-compiler', '~> 1.1'
-  spec.add_development_dependency 'sassc',            '~> 2.0'
+  spec.add_development_dependency 'sass-embedded',    '~> 1.63'
 
   spec.add_development_dependency 'coffee-script',    '~> 2.3'
   spec.add_development_dependency 'babel-transpiler', '~> 0.7'

--- a/lib/hanami/assets/compilers/sass.rb
+++ b/lib/hanami/assets/compilers/sass.rb
@@ -27,7 +27,8 @@ module Hanami
         # @api private
         def initialize(*)
           super
-          require "sassc"
+          require "sass-embedded"
+          require "uri"
         end
 
         private
@@ -35,29 +36,54 @@ module Hanami
         # @since 0.3.0
         # @api private
         def renderer
-          @renderer ||=
-            ::SassC::Engine.new(
-              source.read,
-              syntax: target_syntax,
-              load_paths: load_paths
-            )
+          @renderer ||= SassRenderer.new(source, load_paths: load_paths)
         end
 
         # @since 0.3.0
         # @api private
         def dependencies
-          renderer.dependencies.map(&:filename)
-        rescue source::NotRenderedError
-          []
+          renderer.dependencies
         end
 
-        # @since 1.3.2
+        # @since 2.0.0
         # @api private
-        def target_syntax
-          if source.extname =~ /sass\z/.freeze
-            :sass
-          else
-            :scss
+        class SassRenderer
+          # @since 2.0.0
+          # @api private
+          FILE_URL_PARSER = URI::Parser.new({RESERVED: ";/?:@&=+$,"})
+
+          # @since 2.0.0
+          # @api private
+          def initialize(source, **kwargs)
+            @source = source
+            @kwargs = kwargs
+          end
+
+          # @since 2.0.0
+          # @api private
+          def render
+            result = ::Sass.compile(@source, **@kwargs)
+            @loaded_urls = result.loaded_urls
+            result.css
+          rescue ::Sass::CompileError => exception
+            @loaded_urls = exception.loaded_urls
+            raise
+          end
+
+          # @since 2.0.0
+          # @api private
+          def dependencies
+            return [] unless @loaded_urls
+
+            @loaded_urls.filter_map do |url|
+              if url.start_with?("file:")
+                path = FILE_URL_PARSER.unescape(FILE_URL_PARSER.parse(url).path)
+                if Gem.win_platform? && path[0].chr == "/" && path[1].chr =~ /[a-z]/i && path[2].chr == ":"
+                  path = path[1..]
+                end
+                path
+              end
+            end
           end
         end
       end

--- a/lib/hanami/assets/compressors/sass_stylesheet.rb
+++ b/lib/hanami/assets/compressors/sass_stylesheet.rb
@@ -5,30 +5,24 @@ module Hanami
     module Compressors
       # Sass compressor for stylesheet
       #
-      # It depends on <tt>sassc</tt> gem.
+      # It depends on <tt>sass-embedded</tt> gem.
       #
       # @since 0.1.0
       # @api private
       #
       # @see http://sass-lang.com
-      # @see https://rubygems.org/gems/sass
+      # @see https://rubygems.org/gems/sass-embedded
       class SassStylesheet < Stylesheet
         # @since 0.1.0
         # @api private
         def initialize
-          require 'sassc'
-          @compressor = ::SassC::Engine
+          require 'sass-embedded'
         end
 
         # @since 0.1.0
         # @api private
         def compress(filename)
-          compressor.new(
-            read(filename),
-            filename: filename,
-            syntax: :scss,
-            style: :compressed
-          ).render
+          ::Sass.compile(filename, style: :compressed).css
         end
       end
     end

--- a/lib/hanami/assets/configuration.rb
+++ b/lib/hanami/assets/configuration.rb
@@ -238,7 +238,7 @@ module Hanami
       #   * <tt>:builtin</tt> - Ruby based compressor. It doesn't require any external gem.
       #                         It's fast, but not an efficient compressor.
       #   * <tt>:yui</tt> - YUI-Compressor, it depends on <tt>yui-compressor</tt> gem and requires Java 1.4+
-      #   * <tt>:sass</tt> - Sass, it depends on <tt>sassc</tt> gem
+      #   * <tt>:sass</tt> - Sass, it depends on <tt>sass-embedded</tt> gem
       #
       # @param value [Symbol,#compress] the compressor
       #
@@ -248,7 +248,7 @@ module Hanami
       # @see https://rubygems.org/gems/yui-compressor
       #
       # @see http://sass-lang.com
-      # @see https://rubygems.org/gems/sassc
+      # @see https://rubygems.org/gems/sass-embedded
       #
       # @example YUI Compressor
       #   require 'hanami/assets'

--- a/spec/integration/hanami/assets/compiler_spec.rb
+++ b/spec/integration/hanami/assets/compiler_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe "Compiler" do
 
     target  = @config.public_directory.join("assets", "compile-sass.css")
     content = target.read
-    expect(content).to match %(body {\n  font: 100% Helvetica, sans-serif;\n  color: #333; }\n)
+    expect(content).to match %(body {\n  font: 100% Helvetica, sans-serif;\n  color: #333;\n})
     expect(content).to match %(p {\n  white-space: pre;)
   end
 
@@ -124,12 +124,12 @@ RSpec.describe "Compiler" do
 
     target  = @config.public_directory.join("assets", "sass-dependencies.css")
     content = target.read
-    expect(content).to match %(body {\n  background-color: green; }\n)
+    expect(content).to match %(body {\n  background-color: green;\n})
 
     dependency.touch("$background-color: blue") do
       Hanami::Assets::Compiler.compile(@config, "sass-dependencies.css")
       content = target.read
-      expect(content).to match %(body {\n  background-color: blue; }\n)
+      expect(content).to match %(body {\n  background-color: blue;\n})
     end
   end
 
@@ -145,12 +145,12 @@ RSpec.describe "Compiler" do
 
       target  = @config.public_directory.join("assets", "sass-transitive-dependencies.css")
       content = target.read
-      expect(content).to match %(body {\n  padding: 0; }\n)
+      expect(content).to match %(body {\n  padding: 0;\n})
 
       dependency.touch("$framework-padding: 1") do
         Hanami::Assets::Compiler.compile(@config, "sass-transitive-dependencies.css")
         content = target.read
-        expect(content).to match %(body {\n  padding: 1; }\n)
+        expect(content).to match %(body {\n  padding: 1;\n})
       end
     end
   end
@@ -165,7 +165,7 @@ RSpec.describe "Compiler" do
 
     target  = @config.public_directory.join("assets", asset_name)
     content = target.read
-    expect(content).to match %(body {\n  margin: 0; }\n)
+    expect(content).to match %(body {\n  margin: 0;\n})
 
     dependency_name = SecureRandom.uuid
     _               = TestFile.new(path: "_#{dependency_name}.sass") do
@@ -175,7 +175,7 @@ RSpec.describe "Compiler" do
     asset.touch("@import #{dependency_name}\n\nbody\n  margin: 0") do
       Hanami::Assets::Compiler.compile(@config, asset_name)
       content = target.read
-      expect(content).to match %(html {\n  padding: 0; }\n\nbody {\n  margin: 0; }\n)
+      expect(content).to match %(html {\n  padding: 0;\n}\n\nbody {\n  margin: 0;\n})
     end
   end
 
@@ -194,12 +194,12 @@ RSpec.describe "Compiler" do
 
     target  = @config.public_directory.join("assets", asset_name)
     content = target.read
-    expect(content).to match %(html {\n  padding: 0; }\n\nbody {\n  margin: 0; }\n)
+    expect(content).to match %(html {\n  padding: 0;\n}\n\nbody {\n  margin: 0;\n})
 
     asset.touch("body\n  margin: 0") do
       Hanami::Assets::Compiler.compile(@config, asset_name)
       content = target.read
-      expect(content).to match %(body {\n  margin: 0; }\n)
+      expect(content).to match %(body {\n  margin: 0;\n})
     end
   end
 
@@ -207,7 +207,7 @@ RSpec.describe "Compiler" do
     Hanami::Assets::Compiler.compile(@config, "compile-scss.css")
 
     target = @config.public_directory.join("assets", "compile-scss.css")
-    expect(target.read).to match %(body {\n  font: 100% Helvetica, sans-serif;\n  color: #fff; }\n)
+    expect(target.read).to match %(body {\n  font: 100% Helvetica, sans-serif;\n  color: #fff;\n})
   end
 
   it "compiles scss asset if direct dependency has changed" do
@@ -219,12 +219,12 @@ RSpec.describe "Compiler" do
 
     target  = @config.public_directory.join("assets", "scss-dependencies.css")
     content = target.read
-    expect(content).to match %(body {\n  background-color: purple; }\n)
+    expect(content).to match %(body {\n  background-color: purple;\n})
 
     dependency.touch("body { background-color: turquoise; }") do
       Hanami::Assets::Compiler.compile(@config, "scss-dependencies.css")
       content = target.read
-      expect(content).to match %(body {\n  background-color: turquoise; }\n)
+      expect(content).to match %(body {\n  background-color: turquoise;\n})
     end
   end
 
@@ -240,12 +240,12 @@ RSpec.describe "Compiler" do
 
       target  = @config.public_directory.join("assets", "scss-transitive-dependencies.css")
       content = target.read
-      expect(content).to match %(body {\n  padding: 0; }\n)
+      expect(content).to match %(body {\n  padding: 0;\n})
 
       dependency.touch("body { padding: 1; }") do
         Hanami::Assets::Compiler.compile(@config, "scss-transitive-dependencies.css")
         content = target.read
-        expect(content).to match %(body {\n  padding: 1; }\n)
+        expect(content).to match %(body {\n  padding: 1;\n})
       end
     end
   end

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "erb"
-require "sassc"
+require "sass-embedded"
 require "coffee_script"
 require "hanami/view"
 require "tilt/erb"


### PR DESCRIPTION
[`libsass` was deprecated](https://sass-lang.com/blog/libsass-is-deprecated), so did `sassc`.

This PR replaces `sassc` with `sass-embedded` gem, which uses [the embedded compiler](https://github.com/sass/dart-sass#embedded-dart-sass) in the current official reference implementation [dart-sass](https://github.com/sass/dart-sass).

Jekyll, Sinatra, Tilt, Haml, and a few other ruby projects already migrated or added support, and I'm working to get more prominent ruby projects migrate over to a dart-sass based solution.

---

I'm an active community contributor on `dart-sass` project and the maintainer of `sass-embedded` gem. Let me know if you have questions.