### PR TITLE
Remove `frozen_string_literal: true` comments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 source "https://rubygems.org"
 gemspec
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rake"
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"

--- a/bin/hanami-assets
+++ b/bin/hanami-assets
@@ -1,6 +1,4 @@
 #!/usr/bin/env ruby
-# frozen_string_literal: true
-
 require "optparse"
 require "pathname"
 

--- a/lib/hanami/assets.rb
+++ b/lib/hanami/assets.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/utils/class_attribute"
 
 # Hanami

--- a/lib/hanami/assets/bundler.rb
+++ b/lib/hanami/assets/bundler.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "fileutils"
 require "json"
 

--- a/lib/hanami/assets/bundler/asset.rb
+++ b/lib/hanami/assets/bundler/asset.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "openssl"
 
 module Hanami

--- a/lib/hanami/assets/bundler/compressor.rb
+++ b/lib/hanami/assets/bundler/compressor.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   module Assets
     class Bundler

--- a/lib/hanami/assets/bundler/manifest_entry.rb
+++ b/lib/hanami/assets/bundler/manifest_entry.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   module Assets
     class Bundler

--- a/lib/hanami/assets/cache.rb
+++ b/lib/hanami/assets/cache.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "pathname"
 
 module Hanami

--- a/lib/hanami/assets/compiler.rb
+++ b/lib/hanami/assets/compiler.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "set"
 require "find"
 require "hanami/utils/class_attribute"

--- a/lib/hanami/assets/compilers/less.rb
+++ b/lib/hanami/assets/compilers/less.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   module Assets
     module Compilers

--- a/lib/hanami/assets/compilers/sass.rb
+++ b/lib/hanami/assets/compilers/sass.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   module Assets
     module Compilers

--- a/lib/hanami/assets/config/global_sources.rb
+++ b/lib/hanami/assets/config/global_sources.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/utils/load_paths"
 
 module Hanami

--- a/lib/hanami/assets/config/manifest.rb
+++ b/lib/hanami/assets/config/manifest.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   module Assets
     # This error is raised when the application starts but can't be load the

--- a/lib/hanami/assets/config/sources.rb
+++ b/lib/hanami/assets/config/sources.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/utils/load_paths"
 require "hanami/utils/file_list"
 

--- a/lib/hanami/assets/configuration.rb
+++ b/lib/hanami/assets/configuration.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "pathname"
 require "json"
 require "hanami/utils/string"

--- a/lib/hanami/assets/helpers.rb
+++ b/lib/hanami/assets/helpers.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "uri"
 require "hanami/helpers/html_helper"
 require "hanami/utils/escape"

--- a/lib/hanami/assets/precompiler.rb
+++ b/lib/hanami/assets/precompiler.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "fileutils"
 require "hanami/assets/compiler"
 

--- a/lib/hanami/assets/version.rb
+++ b/lib/hanami/assets/version.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   module Assets
     # Defines the version

--- a/spec/integration/hanami/assets/compiler_spec.rb
+++ b/spec/integration/hanami/assets/compiler_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "tilt/sass"
 require "tilt/coffee"
 require "hanami/assets/compiler"

--- a/spec/integration/hanami/assets/fingerprint_spec.rb
+++ b/spec/integration/hanami/assets/fingerprint_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "Fingerprint mode" do
   before do
     dest.rmtree if dest.exist?

--- a/spec/integration/hanami/assets/precompile_spec.rb
+++ b/spec/integration/hanami/assets/precompile_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "digest"
 require "open3"
 

--- a/spec/integration/hanami/assets/rendering_spec.rb
+++ b/spec/integration/hanami/assets/rendering_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "Rendering test" do
   before do
     Hanami::Assets.configuration.reset!

--- a/spec/integration/hanami/assets/third_party_gems_spec.rb
+++ b/spec/integration/hanami/assets/third_party_gems_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "#{__dir__}/../../../support/fixtures/bookshelf/config/environment"
 
 RSpec.describe "Third part gems integration" do

--- a/spec/integration/hanami/assets/view_spec.rb
+++ b/spec/integration/hanami/assets/view_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "#{__dir__}/../../../support/fixtures/bookshelf/config/environment"
 
 RSpec.describe "Hanami::View integration" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 $LOAD_PATH.unshift "lib"
 require "hanami/utils"
 require "hanami/devtools/unit"

--- a/spec/support/ci.rb
+++ b/spec/support/ci.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module CI
   def self.enabled?
     ENV["CI"]

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "erb"
 require "sassc"
 require "coffee_script"

--- a/spec/support/fixtures/bookshelf/config/environment.rb
+++ b/spec/support/fixtures/bookshelf/config/environment.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rubygems"
 require "bundler/setup"
 require "hanami/view"

--- a/spec/support/fixtures/hanami-compass/Gemfile
+++ b/spec/support/fixtures/hanami-compass/Gemfile
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 source "https://rubygems.org"
 
 # Specify your gem's dependencies in hanami-compass.gemspec

--- a/spec/support/fixtures/hanami-compass/Rakefile
+++ b/spec/support/fixtures/hanami-compass/Rakefile
@@ -1,3 +1,1 @@
-# frozen_string_literal: true
-
 require "bundler/gem_tasks"

--- a/spec/support/fixtures/hanami-compass/bin/console
+++ b/spec/support/fixtures/hanami-compass/bin/console
@@ -1,6 +1,4 @@
 #!/usr/bin/env ruby
-# frozen_string_literal: true
-
 require "bundler/setup"
 require "hanami/compass"
 

--- a/spec/support/fixtures/hanami-compass/lib/hanami/compass.rb
+++ b/spec/support/fixtures/hanami-compass/lib/hanami/compass.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/assets"
 
 module Hanami

--- a/spec/support/fixtures/hanami-compass/lib/hanami/compass/version.rb
+++ b/spec/support/fixtures/hanami-compass/lib/hanami/compass/version.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   module Compass
     VERSION = "0.1.0"

--- a/spec/support/fixtures/hanami-emberjs/Gemfile
+++ b/spec/support/fixtures/hanami-emberjs/Gemfile
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 source "https://rubygems.org"
 
 # Specify your gem's dependencies in hanami-emberjs.gemspec

--- a/spec/support/fixtures/hanami-emberjs/Rakefile
+++ b/spec/support/fixtures/hanami-emberjs/Rakefile
@@ -1,3 +1,1 @@
-# frozen_string_literal: true
-
 require "bundler/gem_tasks"

--- a/spec/support/fixtures/hanami-emberjs/bin/console
+++ b/spec/support/fixtures/hanami-emberjs/bin/console
@@ -1,6 +1,4 @@
 #!/usr/bin/env ruby
-# frozen_string_literal: true
-
 require "bundler/setup"
 require "hanami/emberjs"
 

--- a/spec/support/fixtures/hanami-emberjs/lib/hanami/emberjs.rb
+++ b/spec/support/fixtures/hanami-emberjs/lib/hanami/emberjs.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/assets"
 
 module Hanami

--- a/spec/support/fixtures/hanami-emberjs/lib/hanami/emberjs/version.rb
+++ b/spec/support/fixtures/hanami-emberjs/lib/hanami/emberjs/version.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   module Emberjs
     VERSION = "0.1.0"

--- a/spec/support/fixtures/hanami-foo-compressor/Gemfile
+++ b/spec/support/fixtures/hanami-foo-compressor/Gemfile
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 source "https://rubygems.org"
 
 # Specify your gem's dependencies in hanami-foo-compressor.gemspec

--- a/spec/support/fixtures/hanami-foo-compressor/Rakefile
+++ b/spec/support/fixtures/hanami-foo-compressor/Rakefile
@@ -1,4 +1,2 @@
-# frozen_string_literal: true
-
 require "bundler/gem_tasks"
 task default: :spec

--- a/spec/support/fixtures/hanami-foo-compressor/bin/console
+++ b/spec/support/fixtures/hanami-foo-compressor/bin/console
@@ -1,6 +1,4 @@
 #!/usr/bin/env ruby
-# frozen_string_literal: true
-
 require "bundler/setup"
 require "hanami/foo/compressor"
 

--- a/spec/support/fixtures/hanami-foo-compressor/lib/hanami/assets/compressors/foo_javascript.rb
+++ b/spec/support/fixtures/hanami-foo-compressor/lib/hanami/assets/compressors/foo_javascript.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/assets/compressors/javascript"
 
 module Hanami

--- a/spec/support/fixtures/hanami-foo-compressor/lib/hanami/assets/compressors/foo_stylesheet.rb
+++ b/spec/support/fixtures/hanami-foo-compressor/lib/hanami/assets/compressors/foo_stylesheet.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/assets/compressors/stylesheet"
 
 module Hanami

--- a/spec/support/fixtures/hanami-foo-compressor/lib/hanami/foo/compressor.rb
+++ b/spec/support/fixtures/hanami-foo-compressor/lib/hanami/foo/compressor.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/foo/compressor/version"
 
 module Hanami

--- a/spec/support/fixtures/hanami-foo-compressor/lib/hanami/foo/compressor/version.rb
+++ b/spec/support/fixtures/hanami-foo-compressor/lib/hanami/foo/compressor/version.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   module Foo
     module Compressor

--- a/spec/support/fixtures/standalone/config/environment.rb
+++ b/spec/support/fixtures/standalone/config/environment.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rubygems"
 require "bundler/setup"
 require "hanami/view"

--- a/spec/support/global_sources.rb
+++ b/spec/support/global_sources.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 Hanami::Assets::Config::GlobalSources.class_eval do
   def clear
     @paths.each do |path|

--- a/spec/support/load_paths.rb
+++ b/spec/support/load_paths.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 Hanami::Utils::LoadPaths.class_eval do
   def empty?
     @paths.empty?

--- a/spec/support/rspec.rb
+++ b/spec/support/rspec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rspec"
 
 RSpec.configure do |config|

--- a/spec/support/test_file.rb
+++ b/spec/support/test_file.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "securerandom"
 require_relative "ci"
 require_relative "tmp"

--- a/spec/support/tmp.rb
+++ b/spec/support/tmp.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "pathname"
 
 # TMP = Pathname.new(__dir__).join("..", "tmp")

--- a/spec/unit/hanami/assets/bundler_spec.rb
+++ b/spec/unit/hanami/assets/bundler_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/assets/bundler"
 require "hanami/assets/compressors/javascript"
 require "hanami/assets/compressors/stylesheet"

--- a/spec/unit/hanami/assets/cache_spec.rb
+++ b/spec/unit/hanami/assets/cache_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/assets/cache"
 
 RSpec.describe Hanami::Assets::Cache do

--- a/spec/unit/hanami/assets/compressors/builtin_stylesheet_spec.rb
+++ b/spec/unit/hanami/assets/compressors/builtin_stylesheet_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/assets/compressors/builtin_stylesheet"
 
 RSpec.describe Hanami::Assets::Compressors::BuiltinStylesheet do

--- a/spec/unit/hanami/assets/compressors/javascript_spec.rb
+++ b/spec/unit/hanami/assets/compressors/javascript_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/assets/compressors/javascript"
 require "hanami/foo/compressor"
 

--- a/spec/unit/hanami/assets/compressors/stylesheet_spec.rb
+++ b/spec/unit/hanami/assets/compressors/stylesheet_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/assets/compressors/stylesheet"
 require "hanami/foo/compressor"
 

--- a/spec/unit/hanami/assets/config/null_manifest_spec.rb
+++ b/spec/unit/hanami/assets/config/null_manifest_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "pp"
 
 RSpec.describe Hanami::Assets::Config::NullManifest do

--- a/spec/unit/hanami/assets/configuration_spec.rb
+++ b/spec/unit/hanami/assets/configuration_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/assets/compressors/javascript"
 require "hanami/assets/compressors/stylesheet"
 

--- a/spec/unit/hanami/assets/helpers_spec.rb
+++ b/spec/unit/hanami/assets/helpers_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::Assets::Helpers do
   let(:view)    { ImageHelperView.new({}, **{}) }
   let(:cdn_url) { "https://bookshelf.cdn-example.com" }

--- a/spec/unit/hanami/assets/version_spec.rb
+++ b/spec/unit/hanami/assets/version_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "Hanami::Assets::VERSION" do
   it "exposes version" do
     expect(Hanami::Assets::VERSION).to eq("2.0.0.alpha1")

--- a/spec/unit/hanami/assets_spec.rb
+++ b/spec/unit/hanami/assets_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::Assets do
   describe ".sources" do
     before do


### PR DESCRIPTION
Since we've moved to requiring Ruby >= 3.0 we no longer need to have the
`#frozen_string_literal: true` magic comment as strings are now frozen
by default.