### PR TITLE
Use Zeitwerk for code loading

### DIFF
--- a/hanami-assets.gemspec
+++ b/hanami-assets.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |spec|
   spec.metadata["rubygems_mfa_required"] = "true"
   spec.required_ruby_version = ">= 3.0"
 
+  spec.add_runtime_dependency "zeitwerk", "~> 2.6"
+
   spec.add_development_dependency "bundler", ">= 1.6", "< 3"
   spec.add_development_dependency "rake", "~> 13"
   spec.add_development_dependency "rspec", "~> 3.9"

--- a/lib/hanami-assets.rb
+++ b/lib/hanami-assets.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require_relative "hanami/assets"

--- a/lib/hanami/assets.rb
+++ b/lib/hanami/assets.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "json"
+require "zeitwerk"
 
 # Hanami
 #
@@ -10,10 +11,25 @@ module Hanami
   #
   # @since 0.1.0
   class Assets
-    require "hanami/assets/version"
-    require "hanami/assets/asset"
-    require "hanami/assets/errors"
-    require "hanami/assets/config"
+    # @since 2.1.0
+    # @api private
+    def self.gem_loader
+      @gem_loader ||= Zeitwerk::Loader.new.tap do |loader|
+        root = File.expand_path("..", __dir__)
+        loader.tag = "hanami-assets"
+        loader.push_dir(root)
+        loader.ignore(
+          "#{root}/hanami-assets.rb",
+          "#{root}/hanami/assets/version.rb",
+          "#{root}/hanami/assets/errors.rb"
+        )
+        loader.inflector = Zeitwerk::GemInflector.new("#{root}/hanami-assets.rb")
+      end
+    end
+
+    gem_loader.setup
+    require_relative "assets/version"
+    require_relative "assets/errors"
 
     # @since 2.1.0
     # @api private

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "rspec"
-require "hanami/assets"
+require "hanami-assets"
 require "pathname"
 
 SPEC_ROOT = Pathname(__FILE__).dirname


### PR DESCRIPTION
This follows the standard approach we've used for all our other gems. Notably, it introduces the `lib/hanami-assets.rb` file, which wasn't present before. This will allow hanami-assets to be loaded by a `require "hanami-assets"`, which is a good convention to uphold here.

Resolves #128