### PR TITLE
Use single package_manager_run_command setting

### DIFF
--- a/lib/hanami/assets/config.rb
+++ b/lib/hanami/assets/config.rb
@@ -18,15 +18,7 @@ module Hanami
 
       # @since 2.1.0
       # @api private
-      setting :package_manager_executable, default: "npm"
-
-      # @since 2.1.0
-      # @api private
-      setting :package_manager_command, default: "exec"
-
-      # @since 2.1.0
-      # @api private
-      setting :executable, default: "hanami-assets"
+      setting :package_manager_run_command, default: "npm run --silent"
 
       # @since 2.1.0
       # @api private


### PR DESCRIPTION
Now that we’re generating a `config/asset.mjs` and going to use package.json `"scripts"` entries for the assets commands, we only need a single setting to determine how to run these: `package_manager_run_command`, which defaults to `"npm run"`.