### PR TITLE
Require a root when initializing assets

### DIFF
--- a/lib/hanami/assets/config.rb
+++ b/lib/hanami/assets/config.rb
@@ -17,6 +17,13 @@ module Hanami
       BASE_URL = ""
       private_constant :BASE_URL
 
+      # @!attribute [rw] manifest_path
+      #   @return [String, nil]
+      #
+      #   @api public
+      #   @since 2.1.0
+      setting :manifest_path, default: "assets.json"
+
       # @!attribute [rw] package_manager_run_command
       #   @return [String]
       #
@@ -50,13 +57,6 @@ module Hanami
       #   @api public
       #   @since 2.1.0
       setting :base_url, constructor: -> url { BaseUrl.new(url.to_s) }
-
-      # @!attribute [rw] manifest_path
-      #   @return [String, nil]
-      #
-      #   @api public
-      #   @since 2.1.0
-      setting :manifest_path
 
       # @api public
       # @since 2.1.0

--- a/lib/hanami/assets/errors.rb
+++ b/lib/hanami/assets/errors.rb
@@ -9,13 +9,6 @@ module Hanami
     class Error < ::StandardError
     end
 
-    # Error raised when assets config is not valid.
-    #
-    # @api public
-    # @since 2.1.0
-    class ConfigError < Error
-    end
-
     # Error returned when the assets manifest file is missing.
     #
     # @api public

--- a/spec/integration/hanami/assets/manifest_spec.rb
+++ b/spec/integration/hanami/assets/manifest_spec.rb
@@ -3,16 +3,21 @@
 require "tmpdir"
 
 RSpec.describe "manifest handling" do
-  subject(:assets) { Hanami::Assets.new(config: Hanami::Assets::Config.new(**config_kwargs)) }
+  subject(:assets) {
+    Hanami::Assets.new(
+      config: Hanami::Assets::Config.new(**config_kwargs),
+      root: root,
+    )
+  }
 
   let(:config_kwargs) { {} }
 
   context "manifest_path configured and real file exists" do
-    let(:config_kwargs) { {manifest_path: File.join(@dir, "manifest.json")} }
+    let(:root) { @dir }
 
     before do
       @dir = Dir.mktmpdir
-      File.write(File.join(@dir, "manifest.json"), <<~JSON)
+      File.write(File.join(@dir, "assets.json"), <<~JSON)
         {
           "app.js": {"url": "/path/to/app.js"}
         }
@@ -33,19 +38,12 @@ RSpec.describe "manifest handling" do
     end
   end
 
-  context "manifest_path not configured" do
-    it "raises a ConfigError" do
-      expect { assets["app.js"] }
-        .to raise_error Hanami::Assets::ConfigError, "no manifest_path configured"
-    end
-  end
-
   context "no file at configured manifest_path" do
-    let(:config_kwargs) { {manifest_path: "/missing/manifest.json"} }
+    let(:root) { "/missing/dir" }
 
     it "raises a ManifestMissingError" do
       expect { assets["app.js"] }
-        .to raise_error Hanami::Assets::ManifestMissingError, %r{/missing/manifest.json}
+        .to raise_error Hanami::Assets::ManifestMissingError, %r{/missing/dir/assets.json}
     end
   end
 end


### PR DESCRIPTION
Assets now requires a root, e.g.

```ruby
assets = Hanami::Assets.new(config: Hanami::Assets::Config.new, root: "/some/path")
```

This makes it easier to use separate assets objects for different sets of compiled assets at different paths.

Along with this, make the default config more useful by providing a default value of `"assets.json"` for the `manifest_path` setting.