### PR TITLE
Change manifest_path from a setting to a constant

### DIFF
--- a/lib/hanami/assets.rb
+++ b/lib/hanami/assets.rb
@@ -31,11 +31,6 @@ module Hanami
 
     # @api private
     # @since 2.1.0
-    SEPARATOR = "/"
-    private_constant :SEPARATOR
-
-    # @api private
-    # @since 2.1.0
     attr_reader :config
 
     # @api private

--- a/lib/hanami/assets.rb
+++ b/lib/hanami/assets.rb
@@ -31,6 +31,11 @@ module Hanami
 
     # @api private
     # @since 2.1.0
+    MANIFEST_PATH = "assets.json"
+    private_constant :MANIFEST_PATH
+
+    # @api private
+    # @since 2.1.0
     attr_reader :config
 
     # @api private
@@ -93,7 +98,7 @@ module Hanami
     def manifest
       return @manifest if instance_variable_defined?(:@manifest)
 
-      full_manifest_path = root.join(config.manifest_path)
+      full_manifest_path = root.join(MANIFEST_PATH)
 
       unless full_manifest_path.exist?
         raise ManifestMissingError.new(full_manifest_path.to_s)

--- a/lib/hanami/assets/base_url.rb
+++ b/lib/hanami/assets/base_url.rb
@@ -9,11 +9,6 @@ module Hanami
     class BaseUrl
       # @since 2.1.0
       # @api private
-      SEPARATOR = "/"
-      private_constant :SEPARATOR
-
-      # @since 2.1.0
-      # @api private
       attr_reader :url
       private :url
 

--- a/lib/hanami/assets/config.rb
+++ b/lib/hanami/assets/config.rb
@@ -17,13 +17,6 @@ module Hanami
       BASE_URL = ""
       private_constant :BASE_URL
 
-      # @!attribute [rw] manifest_path
-      #   @return [String, nil]
-      #
-      #   @api public
-      #   @since 2.1.0
-      setting :manifest_path, default: "assets.json"
-
       # @!attribute [rw] node_command
       #   @return [String]
       #


### PR DESCRIPTION
Switch manifest_path from a setting to a constant. This is an internal detail and not necessary to be user configurable. We also hardcode this file name in assets-js.

Fixes #137