### PR TITLE
Add public_assets_dir utility method

### DIFF
--- a/lib/hanami/assets.rb
+++ b/lib/hanami/assets.rb
@@ -29,6 +29,20 @@ module Hanami
     require_relative "assets/version"
     require_relative "assets/errors"
 
+    # Returns the directory (under `public/assets/`) to be used for storing a slice's compiled
+    # assets.
+    #
+    # This is shared logic used by both Hanami (for the assets provider) and Hanami::CLI (for the
+    # assets commands).
+    #
+    # @since 2.1.0
+    # @api private
+    def self.public_assets_dir(slice)
+      return nil if slice.app.eql?(slice)
+
+      slice.slice_name.to_s.split("/").map { |name| "_#{name}" }.join("/")
+    end
+
     # @api private
     # @since 2.1.0
     MANIFEST_PATH = "assets.json"

--- a/spec/unit/hanami/assets/public_assets_dir_spec.rb
+++ b/spec/unit/hanami/assets/public_assets_dir_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+RSpec.describe Hanami::Assets, ".public_assets_dir" do
+  subject(:public_assets_dir) { described_class.public_assets_dir(slice) }
+
+  let(:slice) { double(:slice, slice_name: double(to_s: slice_name), app: double(:app)) }
+  let(:slice_name) { "main" }
+
+  describe "top-level slices" do
+    it "underscores the slice name" do
+      expect(public_assets_dir).to eq "_main"
+    end
+  end
+
+  describe "nested slices" do
+    let(:slice_name) { "main/nested" }
+
+    it "underscores all name segments" do
+      expect(public_assets_dir).to eq "_main/_nested"
+    end
+  end
+
+  describe "app" do
+    before do
+      allow(slice).to receive(:app) { slice }
+    end
+
+    it "returns nil" do
+      expect(public_assets_dir).to be nil
+    end
+  end
+end


### PR DESCRIPTION
This will be used by hanami and hanami-cli to determine the dir under public/assets/ to be used for each slice’s compiled assets.