### PR TITLE
Fix development bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.ruby-version
 *.gem
 *.rbc
 .bundle

--- a/README.md
+++ b/README.md
@@ -247,7 +247,8 @@ Install:
 
 ```bash
 $ npm install
-$ bundle exec rake test
+$ bundle install
+$ bundle exec rake spec
 ```
 
 ## Versioning


### PR DESCRIPTION
Two little tings:

* Fix instructions for local development (how to run the test suite).
* Ignore `.ruby-version` since it's not currently checked in and considered best practice not to check it into the repo for gems.